### PR TITLE
feat(home-assistant): add hostNetwork option to statefulset.yaml and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `podSecurityContext` | Pod security context settings | `{}` |
 | `env` | Environment variables | `[]` |
 | `envFrom` | Use environment variables from ConfigMaps or Secrets | `[]` |
+| `hostNetwork` | Specifies if the containers should be started in `hostNetwork` mode. | `false` |
 | `hostPort.enabled` | Enable 'hostPort' or not | `false` |
 | `hostPort.port` | Port number | `8123` |
 | `service.type` | Service type (ClusterIP, NodePort, LoadBalancer, or ExternalName) | `ClusterIP` |

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -19,6 +19,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.hostNetwork }}
+      hostNetwork: true
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -68,6 +68,11 @@ hostPort:
   enabled: false
   port: 8123
 
+# Specifies if the containers should be started in hostNetwork mode.
+#
+# Required for use auto-discovery feature of Home Assistant
+hostNetwork: false
+
 # Container security context settings
 securityContext: {}
   # capabilities:


### PR DESCRIPTION
…values.yaml

Add `hostNetwork` option to `statefulset.yaml` and `values.yaml` to allow containers to be started in `hostNetwork` mode. This is required for the use of the auto-discovery feature of Home Assistant. The default value is `false`.