### PR TITLE
codeserver service should be created only if the codeserver addon is enabled

### DIFF
--- a/charts/home-assistant/templates/service-codeserver.yaml
+++ b/charts/home-assistant/templates/service-codeserver.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.addons.codeserver  -}}
+{{- if and .Values.addons.codeserver.enabled  -}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
I did not enabled codeserver addon but I've noticed the service is created anyway