### PR TITLE
Add support for additional container ports and services

### DIFF
--- a/charts/home-assistant/templates/service.yaml
+++ b/charts/home-assistant/templates/service.yaml
@@ -17,3 +17,34 @@ spec:
       name: http
   selector:
     {{- include "home-assistant.selectorLabels" . | nindent 4 }}
+
+{{- if .Values.additionalServices }}
+{{- range .Values.additionalServices }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "home-assistant.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "home-assistant.labels" $ | nindent 4 }}
+  {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{ end }}
+spec:
+  type: {{ .type }}
+  ports:
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+  selector:
+    {{- include "home-assistant.selectorLabels" $ | nindent 4 }}
+{{- end }}
+{{- end}}

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -53,6 +53,9 @@ spec:
               {{- if .Values.hostPort.enabled }}
               hostPort: {{ .Values.hostPort.port }}
               {{- end }}
+          {{- if .Values.additionalPorts }}
+            {{- .Values.additionalPorts | toYaml | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -171,6 +171,21 @@ additionalMounts: []
   # - mountPath: /dev/ttyACM0
   #   name: usb
 
+# if you need to expose additional ports
+additionalPorts: []
+#  - name: sia
+#    containerPort: 8124
+#    protocol: TCP
+
+# if you need to expose additional services
+additionalServices: []
+#  - name: sia
+#    port: 8124
+#    targetPort: sia
+#    type: NodePort
+#    protocol: TCP
+#    nodePort: 30124
+
 # Addons configuration for additional services
 addons:
   # Code-server addon configuration


### PR DESCRIPTION
Add support for defining additional container ports and services.

Use case: https://www.home-assistant.io/integrations/sia/
