### PR TITLE
Add pvc

### DIFF
--- a/charts/home-assistant/templates/pvc.yaml
+++ b/charts/home-assistant/templates/pvc.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name:  {{ include "home-assistant.fullname" . }}
+  labels:
+      {{- include "home-assistant.labels" . | nindent 4 }}
+    {{- with .Values.persistence.annotations }}
+    annotations:
+      {{- toYaml . | nindent 4 }}
+    {{ end }}
+spec:
+  accessModes:
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.persistence.matchLabels (.Values.persistence.matchExpressions) }}
+  selector:
+  {{- if .Values.persistence.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.persistence.matchLabels | indent 8 }}
+  {{- end -}}
+  {{- if .Values.persistence.matchExpressions }}
+    matchExpressions:
+{{ toYaml .Values.persistence.matchExpressions | indent 8 }}
+  {{- end -}}
+  {{- end }}
+{{- end -}}

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -114,7 +114,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if or (.Values.persistence.enabled) .Values.additionalVolumes }}
       volumes:
       - name: {{ include "home-assistant.fullname" . }}
       {{- if not .Values.persistence.enabled }}
@@ -130,4 +129,3 @@ spec:
       {{- if .Values.additionalVolumes }}
         {{- .Values.additionalVolumes | toYaml | nindent 6 }}
       {{- end }}
-    {{- end }}

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -116,26 +116,18 @@ spec:
     {{- end }}
     {{- if or (not .Values.persistence.enabled) .Values.additionalVolumes }}
       volumes:
-      {{- if not .Values.persistence.enabled }}
       - name: {{ include "home-assistant.fullname" . }}
+      {{- if not .Values.persistence.enabled }}
         emptyDir: {}
+      {{- else }}
+        persistentVolumeClaim:
+      {{- if .Values.persistence.existingClaim }}
+          claimName: {{ .Values.persistence.existingClaim }}
+      {{- else }}
+          claimName: {{include "home-assistant.fullname" . }}
+      {{- end }}
       {{- end }}
       {{- if .Values.additionalVolumes }}
         {{- .Values.additionalVolumes | toYaml | nindent 6 }}
       {{- end }}
     {{- end }}
-  {{- if .Values.persistence.enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: {{ include "home-assistant.fullname" . }}
-    spec:
-      accessModes:
-        - {{ .Values.persistence.accessMode }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.size }}
-      {{- if .Values.persistence.storageClass }}
-      storageClassName: {{ .Values.persistence.storageClass }}
-      {{- end }}
-  {{- end }}
-  

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -114,7 +114,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if or (not .Values.persistence.enabled) .Values.additionalVolumes }}
+    {{- if or (.Values.persistence.enabled) .Values.additionalVolumes }}
       volumes:
       - name: {{ include "home-assistant.fullname" . }}
       {{- if not .Values.persistence.enabled }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -161,11 +161,11 @@ persistence:
   # Name of the existing persistent volume claim for the stateful set, this option can be used to use existing volumes
   existingClaim: ""
   # Annotations to add to the pvc
-  annotations: { }
+  annotations: {}
   ## Persistent Volume selectors
   ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
-  matchLabels: { }
-  matchExpressions: { }
+  matchLabels: {}
+  matchExpressions: {}
 
 # if you need any additional volumes, you can define them here
 additionalVolumes: []

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -158,6 +158,14 @@ persistence:
   size: 5Gi
   # Storage class for the persistent volume claim
   storageClass: ""
+  # Name of the existing persistent volume claim for the stateful set, this option can be used to use existing volumes
+  existingClaim: ""
+  # Annotations to add to the pvc
+  annotations: { }
+  ## Persistent Volume selectors
+  ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
+  matchLabels: { }
+  matchExpressions: { }
 
 # if you need any additional volumes, you can define them here
 additionalVolumes: []


### PR DESCRIPTION
This PR transform the stateful set claim template to a rendered PVC. This enables reusing existing PVCs so the data can be used between cluster re installs without restoring backups. It also enables estaticly provisioning the volumes (PV and PVC), so there's an escape hatch for the complex configuration required by home-assistant.

The PVC (instead of template) also has been augmented to allow selector and annotations.



