### PR TITLE
feat: Enable statically provisioned volumes

### DIFF
--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -114,7 +114,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if or (not .Values.persistence.enabled) .Values.additionalVolumes }}
       volumes:
       {{- if not .Values.persistence.enabled }}
       - name: {{ include "home-assistant.fullname" . }}
@@ -123,7 +122,6 @@ spec:
       {{- if .Values.additionalVolumes }}
         {{- .Values.additionalVolumes | toYaml | nindent 6 }}
       {{- end }}
-    {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
@@ -131,6 +129,20 @@ spec:
     spec:
       accessModes:
         - {{ .Values.persistence.accessMode }}
+      {{- if .Values.persistence.existingVolume }}
+      volumeName: {{ .Values.persistence.existingVolume }}
+      {{- end }}
+      {{- if or .Values.persistence.matchLabels (.Values.persistence.matchExpressions) }}
+      selector:
+      {{- if .Values.persistence.matchLabels }}
+        matchLabels:
+        {{ toYaml .Values.persistence.matchLabels | indent 8 }}
+      {{- end -}}
+      {{- if .Values.persistence.matchExpressions }}
+        matchExpressions:
+          {{ toYaml .Values.persistence.matchExpressions | indent 8 }}
+        {{- end -}}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -158,6 +158,12 @@ persistence:
   size: 5Gi
   # Storage class for the persistent volume claim
   storageClass: ""
+  # Name of the existing volume claim for the stateful set, this option can be used to use existing volumes
+  existingVolume: ""
+  ## Persistent Volume selectors
+  ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
+  matchLabels: {}
+  matchExpressions: {}
 
 # if you need any additional volumes, you can define them here
 additionalVolumes: []


### PR DESCRIPTION
This change enables modifying the persistentVolumeClaim template to specify:
* volumeName => for statically provisioned single volume
* matchLabels and matchSelector => for multiple volumes (pool) provisioned statically.

Is backwarwards compatible, samples:

```
helm template ./charts/home-assistant --set persistence.enabled=true,persistence.existingVolume=testvolume,persistence.accessMode="ReadWriteOnce",persistence.storageClass="freenas-nfs-csi" | kubectl apply -n persistance-enabled-static  -f - 
```

```
helm template ./charts/home-assistant --set persistence.enabled=true,persistence.existingVolume=testvolume,persistence.accessMode="ReadWrite" | kubectl apply -n persistance-enabled-static  -f **-**
```

```
 kubectl get pods -A | grep persis | grep -v test
persistance-disabled          release-name-home-assistant-0                                  1/1     Running   0          48m
persistance-enabled-dyanmic   release-name-home-assistant-0                                  1/1     Running   0          7m13s
persistance-enabled-static    release-name-home-assistant-0                                  1/1     Running   0          10m
```

```
 kubectl get -A pvc | grep per
persistance-enabled-dyanmic   release-name-home-assistant-release-name-home-assistant-0   Bound     pvc-c5df80c9-a184-443d-8325-2eb613f411e0   5Gi        RWO            freenas-nfs-csi     7m39s
persistance-enabled-static    release-name-home-assistant-release-name-home-assistant-0   Bound     testvolume                                 5Gi        RWO            freenas-nfs-csi     11m

```