### PR TITLE
feat: Add init container to enable ingresses in configuration.yaml

### DIFF
--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -102,6 +102,16 @@ spec:
           - mountPath: /config
             name: {{ include "home-assistant.fullname" . }}
         {{- end }}
+    {{- if and .Values.ingress.enabled .Values.ingress.configureHA }}
+      initContainers:
+        - name: enable-ingress-configuration.yaml
+          image: {{ .Values.yq.repository}}/{{ .Values.yq.tag }}
+          command: [ "/bin/sh" ]
+          args: [ "-c", "touch /config/configuration.yaml; yq -i '.http.use_x_forwarded_for = true' configuration.yaml; /config/configuration.yaml; yq -i '.http.trusted_proxies = [ \"10.0.0.0/8\", \"172.16.0.0/12\", \"192.168.0.0/16\" ]' /config/configuration.yaml"  ]
+          volumeMounts:
+          - mountPath: /config
+            name: {{ include "home-assistant.fullname" . }}
+    {{-end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -14,6 +14,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+yq:
+  repository: mikefarah/yq
+  tag: latest
+
 # List of imagePullSecrets for private image repositories
 imagePullSecrets: []
 # Override the default name of the Helm chart
@@ -110,6 +114,9 @@ service:
 ingress:
   # Enable ingress for home assistant
   enabled: false
+  # Configure home assistant - patch configuration.yaml of home assistant, so it allows all private addresses
+  # as origins of proxied traffic
+  configureHA: false
   className: ""
   annotations:
     {}


### PR DESCRIPTION
Create an init container, that updates the ha configuration adding:
```
http:
  use_x_forwarded_for = true
  trusted_proxies:
  - 10.0.0.0/8
  - 172.16.0.0/12
  - 192.168.0.0/16 
```

I'm inlining everything, if more and more features are added, probably we should move this to an script in a config map or template the script.

I have *NOT* Tested this, I'm a bit cramped ATM. If you want to test it yourself o wait it until I can test it, fine for me.