### PR TITLE
support dnsPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `env` | Environment variables | `[]` |
 | `envFrom` | Use environment variables from ConfigMaps or Secrets | `[]` |
 | `hostNetwork` | Specifies if the containers should be started in `hostNetwork` mode. | `false` |
+| `dnsPolicy` | Specifies the [`dnsPolicy`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod. | `false` |
 | `hostPort.enabled` | Enable 'hostPort' or not | `false` |
 | `hostPort.port` | Port number | `8123` |
 | `dnsConfig` | Override the default dnsConfig and set your own nameservers or ndots, among other options | `{}` |

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
     {{- if .Values.hostNetwork }}
       hostNetwork: true
     {{- end }}
+    {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
when running in `hostNetwork: true` mode, without dnsPolicy, kubernetes won't use the cluster nameservers (even if you specify them via dnsConfig, it only adds to the host nameserver set) so internal cluster addresses don't work correctly, the only way to fix this is to specify `dnsPolicy: ClusterFirstWithHostNet`. This would be a noop change for anyone who doesn't explicitly set a dnsPolicy in their values.yaml file