### PR TITLE
change service monitor to use the named port + selectorLabels

### DIFF
--- a/charts/home-assistant/templates/service-monitor.yaml
+++ b/charts/home-assistant/templates/service-monitor.yaml
@@ -5,15 +5,16 @@ metadata:
   name: {{ include "home-assistant.fullname" . }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
+    release: prometheus-operator
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.scrapeInterval }}
-      targetPort: {{ .Values.service.port }}
+      port: http
       path: /api/prometheus
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "home-assistant.labels" . | nindent 6 }}
+      {{- include "home-assistant.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/home-assistant/templates/service-monitor.yaml
+++ b/charts/home-assistant/templates/service-monitor.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "home-assistant.fullname" . }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
-    release: prometheus-operator
+    {{- with .Values.serviceMonitor.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.scrapeInterval }}

--- a/charts/home-assistant/templates/service.yaml
+++ b/charts/home-assistant/templates/service.yaml
@@ -36,6 +36,9 @@ metadata:
   {{ end }}
 spec:
   type: {{ .type }}
+  {{- if .loadBalancerClass}}
+  loadBalancerClass: {{.loadBalancerClass}}
+  {{- end}}
   ports:
     - port: {{ .port }}
       targetPort: {{ .targetPort }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -338,6 +338,7 @@ serviceMonitor:
   # requires HA integration:  https://www.home-assistant.io/integrations/prometheus/
   enabled: false
   scrapeInterval: 30s
+  labels: {}
 
 # Addons configuration for additional services
 addons:


### PR DESCRIPTION
* updates service monitor to use selector labels
* updates service monitor to use targetPort (container port is different so prometheus doesn't match and values don't scrape)
* adds optional labels to the monitor service monitor
* adds support for loadBalancerClass on the additionalServices


If you would prefer these as more discrete pull requests, let me know!