### PR TITLE
Add dnsPolicy example to values.yaml

### DIFF
--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -74,6 +74,10 @@ hostPort:
 # Required for use auto-discovery feature of Home Assistant
 hostNetwork: false
 
+# Set the dnsPolicy (you'll want ClusterFirstWithHostNet if running on hostNetwork to reac
+# other k8s services via DNS
+# dnsPolicy: ClusterFirst
+
 # Container security context settings
 securityContext:
   {}


### PR DESCRIPTION
Some of us weirdos look at the default values.yaml as the main documentation, so this helps with #69