### PR TITLE
Add support for extra user-defined labels on the ingress

### DIFF
--- a/charts/home-assistant/templates/ingress.yaml
+++ b/charts/home-assistant/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -115,6 +115,7 @@ ingress:
   # Enable ingress for home assistant
   enabled: false
   className: ""
+  labels: {}
   annotations:
     {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
This allows custom labels to be defined on the ingress
e.g.
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: home-assistant
  labels:
    helm.sh/chart: home-assistant-0.2.84
    app.kubernetes.io/name: home-assistant
    app.kubernetes.io/instance: home-assistant
    app.kubernetes.io/version: "2024.10.4"
    app.kubernetes.io/managed-by: Helm
    one: two
    three: four
```