### PR TITLE
Add support for user defined annotations on StatefulSet

### DIFF
--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -62,6 +62,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `serviceAccount.create` | Specifies whether a service account should be created | `true` |
 | `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
 | `serviceAccount.name` | The name of the service account to use | `""` |
+| `statefulSetAnnotations` | Annotations to add to the StatefulSet | `{}` |
 | `podAnnotations` | Annotations to add to the pod | `{}` |
 | `podSecurityContext` | Pod security context settings | `{}` |
 | `env` | Environment variables | `[]` |

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "home-assistant.fullname" . }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
+{{- if .Values.statefulSetAnnotations }}
+  annotations:
+    {{- toYaml .Values.statefulSetAnnotations | nindent 4 }}
+{{- end }}
 spec:
   serviceName: {{ include "home-assistant.fullname" . }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -387,3 +387,6 @@ addons:
     additionalMounts: []
       # - mountPath: /home/coder/.ssh/id_rsa
       #   name: id-rsa
+
+# Annotations to add to the stateful set
+statefulSetAnnotations: {}


### PR DESCRIPTION
The goal of this PR is to enable the `StatefulSet` to be annotated, for tools like [keel](https://keel.sh/) to work with this chart.

For example, the following `values.yaml`:

```yaml
statefulSetAnnotations:
  keyOne: valueOne
  keyTwo: valueTwo
```

Would be included in the `StatefulSet` as:

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: home-assistant
  annotations:
    keyOne: valueOne
    keyTwo: valueTwo
```

Sorry for the 3 commits, was doing this from the web UI. If you prefer, I can squash them.