### PR TITLE
New feature: Use an existing ConfigMap for configuration.yaml, force init without a merge

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -17,4 +17,4 @@ sources:
 - https://github.com/cdr/code-server
 - https://github.com/pajikos/home-assistant-helm-chart/tree/main/charts/home-assistant
 type: application
-version: 0.2.109
+version: 0.2.110

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -96,7 +96,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `configuration.mergeConfig` | Will merge the current configuration file with the default configuration on every start                                             | `true` |
 | `configuration.trusted_proxies` | List of trusted proxies in CIDR notation                                                                                            | `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8"]` |
 | `configuration.templateConfig` | Template for the `configuration.yaml` file                                                                                          | See Advanced Configuration |
-| `configuration.useExistingConfigMap` | ConfigMap to use for the `configuration.yaml` file.                                                                                 | See Advanced Configuration |
+| `configuration.useExistingConfigMap` | ConfigMap to use for the `configuration.yaml` file                                                                                 | See Advanced Configuration |
 | `configuration.initScript` | Init script for Home Assistant initialization                                                                                       | See values.yaml for the complete configuration options  |
 | `configuration.initContainer` | Configuration for the init container                                                                                                | See values.yaml for the complete configuration options |
 | `addons.codeserver.enabled` | Enable or disable the code-server addon                                                                                             | `false` |

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -229,10 +229,15 @@ Customize Home Assistant's configuration directly through the Helm chart:
 # Configuration for Home Assistant
 configuration:
   # Enable or disable the configuration setup for Home Assistant
-  enabled: true
-  # Force init will merge the current configuration file with the default configuration on every start
+  enabled: false
+  # Force init will set the current configuration file with the default configuration on every start
   # This is useful when you want to ensure that the configuration file is always up to date
-  forceInit: true
+  forceInit: false
+  # Will merge the current configuration file with the default configuration on every start
+  mergeConfig: true
+  # The name of the ConfigMap to be used. If this value is set, then this ConfigMap will be used for the
+  # configuration.yaml instead of the ConfigMap rendered from templateConfig.
+  useExistingConfigMap: ""
   # List of trusted proxies in the format of CIDR notation in a case of using a reverse proxy
   # Here is the list of the most common private IP ranges, use your list of possible trusted proxies, usually, it's the IP of the reverse proxy
   trusted_proxies:

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -50,64 +50,66 @@ The following table lists the configurable parameters of the Home Assistant char
 
 This document provides detailed configuration options for the Home Assistant Helm chart.
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `replicaCount` | Number of replicas for the deployment | `1` |
-| `image.repository` | Repository for the Home Assistant image | `ghcr.io/home-assistant/home-assistant` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `image.tag` | Overrides the image tag (default is the chart appVersion) | `""` |
-| `image.imagePullSecrets` | List of imagePullSecrets for private image repositories | `[]` |
-| `nameOverride` | Override the default name of the Helm chart | `""` |
-| `fullnameOverride` | Override the default full name of the Helm chart | `""` |
-| `serviceAccount.create` | Specifies whether a service account should be created | `true` |
-| `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
-| `serviceAccount.name` | The name of the service account to use | `""` |
-| `podAnnotations` | Annotations to add to the pod | `{}` |
-| `statefulSetAnnotations` | Annotations to add to the StatefulSet | `{}` |
-| `podSecurityContext` | Pod security context settings | `{}` |
-| `env` | Environment variables | `[]` |
-| `envFrom` | Use environment variables from ConfigMaps or Secrets | `[]` |
-| `hostNetwork` | Specifies if the containers should be started in `hostNetwork` mode. | `false` |
+| Parameter | Description                                                                                                                         | Default |
+| --------- |-------------------------------------------------------------------------------------------------------------------------------------| ------- |
+| `replicaCount` | Number of replicas for the deployment                                                                                               | `1` |
+| `image.repository` | Repository for the Home Assistant image                                                                                             | `ghcr.io/home-assistant/home-assistant` |
+| `image.pullPolicy` | Image pull policy                                                                                                                   | `IfNotPresent` |
+| `image.tag` | Overrides the image tag (default is the chart appVersion)                                                                           | `""` |
+| `image.imagePullSecrets` | List of imagePullSecrets for private image repositories                                                                             | `[]` |
+| `nameOverride` | Override the default name of the Helm chart                                                                                         | `""` |
+| `fullnameOverride` | Override the default full name of the Helm chart                                                                                    | `""` |
+| `serviceAccount.create` | Specifies whether a service account should be created                                                                               | `true` |
+| `serviceAccount.annotations` | Annotations to add to the service account                                                                                           | `{}` |
+| `serviceAccount.name` | The name of the service account to use                                                                                              | `""` |
+| `podAnnotations` | Annotations to add to the pod                                                                                                       | `{}` |
+| `statefulSetAnnotations` | Annotations to add to the StatefulSet                                                                                               | `{}` |
+| `podSecurityContext` | Pod security context settings                                                                                                       | `{}` |
+| `env` | Environment variables                                                                                                               | `[]` |
+| `envFrom` | Use environment variables from ConfigMaps or Secrets                                                                                | `[]` |
+| `hostNetwork` | Specifies if the containers should be started in `hostNetwork` mode.                                                                | `false` |
 | `dnsPolicy` | Specifies the [`dnsPolicy`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod. | `false` |
-| `hostPort.enabled` | Enable 'hostPort' or not | `false` |
-| `hostPort.port` | Port number | `8123` |
-| `dnsConfig` | Override the default dnsConfig and set your own nameservers or ndots, among other options | `{}` |
-| `service.type` | Service type (ClusterIP, NodePort, LoadBalancer, or ExternalName) | `ClusterIP` |
-| `service.port` | Service port | `8080` |
-| `service.annotations` | Annotations to add to the service | `{}` |
-| `ingress.enabled` | Enable ingress for Home Assistant | `false` |
-| `ingress.external` | Enable external ingress (cannot be true when ingress.enabled is true) | `false` |
-| `resources` | Resource settings for the container | `{}` |
-| `nodeSelector` | Node selector settings for scheduling the pod on specific nodes | `{}` |
-| `tolerations` | Tolerations settings for scheduling the pod based on node taints | `[]` |
-| `affinity` | Affinity settings for controlling pod scheduling | `{}` |
-| `persistence.enabled` | Enables the creation of a Persistent Volume Claim (PVC) for Home Assistant. | `false` |
-| `persistence.accessMode` | The access mode of the PVC. | `ReadWriteOnce` |
-| `persistence.size` | The size of the PVC to create. | `5Gi` |
-| `persistence.storageClass` | The storage class to use for the PVC. If empty, the default storage class is used. | `""` |
-| `persistence.existingVolume` | The name of an existing Persistent Volume to bind to. This bypasses dynamic provisioning. | `""` |
-| `persistence.matchLabels` | Label selectors to apply when binding to an existing Persistent Volume. | `{}` |
-| `persistence.matchExpressions` | Expression selectors to apply when binding to an existing Persistent Volume. | `{}` |
-| `additionalVolumes` | Additional volumes to be mounted in the home assistant container | `[]` |
-| `additionalMounts` | Additional volume mounts to be mounted in the home assistant container | `[]` |
-| `initContainers` | List of initialization containers | `[]` |
-| `configuration.enabled` | Enable or disable the configuration setup for Home Assistant | `false` |
-| `configuration.forceInit` | Force init will merge the current configuration file with the default configuration on every start | `false` |
-| `configuration.trusted_proxies` | List of trusted proxies in CIDR notation | `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8"]` |
-| `configuration.templateConfig` | Template for the `configuration.yaml` file | See Advanced Configuration |
-| `configuration.initScript` | Init script for Home Assistant initialization | See values.yaml for the complete configuration options  |
-| `configuration.initContainer` | Configuration for the init container | See values.yaml for the complete configuration options |
-| `addons.codeserver.enabled` | Enable or disable the code-server addon | `false` |
-| `addons.codeserver.resources` | Resource settings for the code-server container | `{}` |
-| `addons.codeserver.image.repository` | Repository for the code-server image | `ghcr.io/coder/code-server` |
-| `addons.codeserver.image.pullPolicy` | Image pull policy for the code-server image | `IfNotPresent` |
-| `addons.codeserver.image.tag` | Tag for the code-server image | `latest released version, automatically updated` |
-| `addons.codeserver.service.type` | Service type for the code-server addon | `ClusterIP` |
-| `addons.codeserver.service.port` | Service port for the code-server addon | `12321` |
-| `addons.codeserver.ingress.enabled` | Enable or disable the ingress for the code-server addon | `false` |
-| `addons.codeserver.ingress.hosts` | Hosts for the code-server addon | `[]` |
-| `addons.codeserver.ingress.tls` | TLS settings for the code-server addon | `[]` |
-| `addons.codeserver.ingress.annotations` | Annotations for the code-server addon | `{}` |
+| `hostPort.enabled` | Enable 'hostPort' or not                                                                                                            | `false` |
+| `hostPort.port` | Port number                                                                                                                         | `8123` |
+| `dnsConfig` | Override the default dnsConfig and set your own nameservers or ndots, among other options                                           | `{}` |
+| `service.type` | Service type (ClusterIP, NodePort, LoadBalancer, or ExternalName)                                                                   | `ClusterIP` |
+| `service.port` | Service port                                                                                                                        | `8080` |
+| `service.annotations` | Annotations to add to the service                                                                                                   | `{}` |
+| `ingress.enabled` | Enable ingress for Home Assistant                                                                                                   | `false` |
+| `ingress.external` | Enable external ingress (cannot be true when ingress.enabled is true)                                                               | `false` |
+| `resources` | Resource settings for the container                                                                                                 | `{}` |
+| `nodeSelector` | Node selector settings for scheduling the pod on specific nodes                                                                     | `{}` |
+| `tolerations` | Tolerations settings for scheduling the pod based on node taints                                                                    | `[]` |
+| `affinity` | Affinity settings for controlling pod scheduling                                                                                    | `{}` |
+| `persistence.enabled` | Enables the creation of a Persistent Volume Claim (PVC) for Home Assistant.                                                         | `false` |
+| `persistence.accessMode` | The access mode of the PVC.                                                                                                         | `ReadWriteOnce` |
+| `persistence.size` | The size of the PVC to create.                                                                                                      | `5Gi` |
+| `persistence.storageClass` | The storage class to use for the PVC. If empty, the default storage class is used.                                                  | `""` |
+| `persistence.existingVolume` | The name of an existing Persistent Volume to bind to. This bypasses dynamic provisioning.                                           | `""` |
+| `persistence.matchLabels` | Label selectors to apply when binding to an existing Persistent Volume.                                                             | `{}` |
+| `persistence.matchExpressions` | Expression selectors to apply when binding to an existing Persistent Volume.                                                        | `{}` |
+| `additionalVolumes` | Additional volumes to be mounted in the home assistant container                                                                    | `[]` |
+| `additionalMounts` | Additional volume mounts to be mounted in the home assistant container                                                              | `[]` |
+| `initContainers` | List of initialization containers                                                                                                   | `[]` |
+| `configuration.enabled` | Enable or disable the configuration setup for Home Assistant                                                                        | `false` |
+| `configuration.forceInit` | Force init will set the current configuration file with the default configuration on every start                                    | `false` |
+| `configuration.mergeConfig` | Will merge the current configuration file with the default configuration on every start                                             | `true` |
+| `configuration.trusted_proxies` | List of trusted proxies in CIDR notation                                                                                            | `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8"]` |
+| `configuration.templateConfig` | Template for the `configuration.yaml` file                                                                                          | See Advanced Configuration |
+| `configuration.useExistingConfigMap` | ConfigMap to use for the `configuration.yaml` file                                                                                  | See Advanced Configuration |
+| `configuration.initScript` | Init script for Home Assistant initialization                                                                                       | See values.yaml for the complete configuration options  |
+| `configuration.initContainer` | Configuration for the init container                                                                                                | See values.yaml for the complete configuration options |
+| `addons.codeserver.enabled` | Enable or disable the code-server addon                                                                                             | `false` |
+| `addons.codeserver.resources` | Resource settings for the code-server container                                                                                     | `{}` |
+| `addons.codeserver.image.repository` | Repository for the code-server image                                                                                                | `ghcr.io/coder/code-server` |
+| `addons.codeserver.image.pullPolicy` | Image pull policy for the code-server image                                                                                         | `IfNotPresent` |
+| `addons.codeserver.image.tag` | Tag for the code-server image                                                                                                       | `latest released version, automatically updated` |
+| `addons.codeserver.service.type` | Service type for the code-server addon                                                                                              | `ClusterIP` |
+| `addons.codeserver.service.port` | Service port for the code-server addon                                                                                              | `12321` |
+| `addons.codeserver.ingress.enabled` | Enable or disable the ingress for the code-server addon                                                                             | `false` |
+| `addons.codeserver.ingress.hosts` | Hosts for the code-server addon                                                                                                     | `[]` |
+| `addons.codeserver.ingress.tls` | TLS settings for the code-server addon                                                                                              | `[]` |
+| `addons.codeserver.ingress.annotations` | Annotations for the code-server addon                                                                                               | `{}` |
 
 ## Persistence
 

--- a/charts/home-assistant/templates/configmap-hass-config.yaml
+++ b/charts/home-assistant/templates/configmap-hass-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configuration.enabled -}}
+{{- if and .Values.configuration.enabled (eq .Values.configuration.useExistingConfigMap "") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -21,7 +21,11 @@ spec:
       annotations:
         {{- if .Values.configuration.enabled }}
         checksum/init-script: {{ include (print $.Template.BasePath "/configmap-init-script.yaml") . | sha256sum }}
-        checksum/hass-configuration: {{ include (print $.Template.BasePath "/configmap-hass-config.yaml") . | sha256sum }}
+        {{- if .Values.configuration.useExistingConfigMap }}
+        checksum/{{ .Values.configuration.useExistingConfigMap }}: {{ (lookup "v1" "ConfigMap" .Release.Namespace .Values.configuration.useExistingConfigMap).data | toJson | sha256sum }}
+        {{- else }}
+        checksum/hass-configuration: {{ "hass-configuration" | sha256sum }}
+        {{- end }}
         {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -174,7 +178,7 @@ spec:
           name: init-script
       - name: config-volume
         configMap:
-          name: hass-configuration
+          name: {{ .Values.configuration.useExistingConfigMap | default "hass-configuration" }}
       {{- end }}
       {{- if not .Values.persistence.enabled }}
       - name: {{ include "home-assistant.fullname" . }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -167,7 +167,7 @@ configuration:
 
   # Force init will set the current configuration file with the default configuration on every start
   # This is useful when you want to ensure that the configuration file is always up to date
-  forceInit: true
+  forceInit: false
 
   # Will merge the current configuration file with the default configuration on every start
   mergeConfig: true

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -164,9 +164,14 @@ initContainers: []
 configuration:
   # Enable or disable the configuration setup for Home Assistant
   enabled: false
-  # Force init will merge the current configuration file with the default configuration on every start
+
+  # Force init will set the current configuration file with the default configuration on every start
   # This is useful when you want to ensure that the configuration file is always up to date
-  forceInit: false
+  forceInit: true
+
+  # Will merge the current configuration file with the default configuration on every start
+  mergeConfig: true
+
   # List of trusted proxies in the format of CIDR notation in a case of using a reverse proxy
   # Here is the list of the most common private IP ranges, use your list of possible trusted proxies, usually, it's the IP of the reverse proxy
   trusted_proxies:
@@ -174,6 +179,11 @@ configuration:
     - 172.16.0.0/12
     - 192.168.0.0/16
     - 127.0.0.0/8
+
+  # The name of the ConfigMap to be used. If this value is set, then this ConfigMap will be used for the
+  # configuration.yaml instead of the ConfigMap rendered from templateConfig.
+  useExistingConfigMap: ""
+
   # Template for the configuration.yaml file
   # Used the `tpl` function to render the template, so you can use Go template functions
   templateConfig: |-
@@ -211,6 +221,8 @@ configuration:
 
     # Check if the force init is enabled
     forceInit="{{ .Values.configuration.forceInit }}"
+    mergeConfig="{{ .Values.configuration.mergeConfig }}"
+    
     if [ "$forceInit" = "true" ]; then
       echo "Force init is enabled, overwriting the configuration file"
       current_time=$(date +%Y%m%d_%H%M%S)
@@ -222,14 +234,18 @@ configuration:
       ls -t /config/configuration.yaml.* 2>/dev/null | tail -n +11 | xargs -r rm
       echo "After cleanup - remaining backup files:"
       ls -l /config/configuration.yaml.*
-      echo "The current configuration file will be merged with the default configuration file with this content:"
-      cat /config-templates/configuration.yaml
-      if [[ ! -s /config/configuration.yaml ]]; then
-        # If /config/configuration.yaml is empty, use the content of /config-templates/configuration.yaml
-        cat /config-templates/configuration.yaml > /config/configuration.yaml
+      if [ "mergeConfig" = "true" ]; then
+        echo "The current configuration file will be merged with the default configuration file with this content:"
+        cat /config-templates/configuration.yaml
+        if [[ ! -s /config/configuration.yaml ]]; then
+          # If /config/configuration.yaml is empty, use the content of /config-templates/configuration.yaml
+          cat /config-templates/configuration.yaml > /config/configuration.yaml
+        else
+          # Perform the merge operation if /config/configuration.yaml is not empty
+          yq eval-all --inplace 'select(fileIndex == 0) *d select(fileIndex == 1)' /config/configuration.yaml /config-templates/configuration.yaml
+        fi
       else
-        # Perform the merge operation if /config/configuration.yaml is not empty
-        yq eval-all --inplace 'select(fileIndex == 0) *d select(fileIndex == 1)' /config/configuration.yaml /config-templates/configuration.yaml
+        cp /config-templates/configuration.yaml /config/configuration.yaml
       fi
     fi
 


### PR DESCRIPTION
This change includes two features:

- The forceInit function has been enhanced so that it still performs a merge by default. However, if forceInit should not perform a merge, the configuration.yaml will be completely reset. For this purpose, a new option mergeInit has been added to the values.yaml, with a default value of true. This default setting ensures backward compatibility.

- The configuration.yaml can now be directly included via an existing ConfigMap. In this case, the ConfigMap replaces the generation from the configTemplate value. This is particularly useful when configuration.yaml contains complex expressions that are difficult or even impossible to represent using configTemplate, as it always passes through the Helm parser. To use an existing ConfigMap as a replacement for hass-configuration, a new value useExistingConfig has been added to values.yaml.