### PR TITLE
Allow setting priorityClassName on pods

### DIFF
--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -81,6 +81,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `nodeSelector` | Node selector settings for scheduling the pod on specific nodes | `{}` |
 | `tolerations` | Tolerations settings for scheduling the pod based on node taints | `[]` |
 | `affinity` | Affinity settings for controlling pod scheduling | `{}` |
+| `priorityClassName` | Priority class name for Home Assistant pods | `""` |
 | `persistence.enabled` | Enables the creation of a Persistent Volume Claim (PVC) for Home Assistant. | `false` |
 | `persistence.accessMode` | The access mode of the PVC. | `ReadWriteOnce` |
 | `persistence.size` | The size of the PVC to create. | `5Gi` |

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -167,6 +167,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       volumes:
       {{- if .Values.configuration.enabled }}
       - name: init-volume

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -155,6 +155,9 @@ tolerations: []
 # Affinity settings for controlling pod scheduling
 affinity: {}
 
+# Set a priorityClassName on Home Assistant pods
+priorityClassName: ""
+
 initContainers: []
   # - name: init-myservice
   #   image: busybox


### PR DESCRIPTION
I have a hardware device attached to my Home Assistant node, so it will only work on one particular node. To make sure that the scheduler makes room for HA (if other workloads have already been scheduled there), I created a priority class. I realised the template doesn't support this yet, so I've added an option.

If `priorityClassName` is set, this allows for a configuration where the scheduler evicts other pods and puts HA on the right node. Here's what that looks like for me (a snippet from my `values.yaml`):

```yaml
priorityClassName: node-priority

nodeSelector:
  zigbee: "true"
```

Of course, there also needs to be a label on the node and the priority class needs to exist.