### PR TITLE
Add support for PVC annotations in Home Assistant Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `persistence.existingVolume` | The name of an existing Persistent Volume to bind to. This bypasses dynamic provisioning. | `""` |
 | `persistence.matchLabels` | Label selectors to apply when binding to an existing Persistent Volume. | `{}` |
 | `persistence.matchExpressions` | Expression selectors to apply when binding to an existing Persistent Volume. | `{}` |
+| `persistence.annotations` | Annotations to add to the PVC. | `{}` |
 | `additionalVolumes` | Additional volumes to be mounted in the home assistant container | `[]` |
 | `additionalMounts` | Additional volume mounts to be mounted in the home assistant container | `[]` |
 | `initContainers` | List of initialization containers | `[]` |
@@ -150,6 +151,18 @@ persistence:
     - key: "failure-domain.beta.kubernetes.io/zone"
       operator: "In"
       values: ["us-west-1a"]
+```
+
+### PVC Annotations
+
+You can add annotations to the PVC by specifying them in the `persistence.annotations` field. This is useful for backup solutions like k8up that use annotations to identify resources for backup.
+
+```yaml
+persistence:
+  enabled: true
+  annotations:
+    k8up.io/backup: "true"
+    another-annotation: "value"
 ```
 
 > **Note**: When specifying an `existingVolume`, ensure that the PV is not already bound to another PVC, as a PV can only be bound to a single PVC at a time.

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -88,6 +88,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `persistence.existingVolume` | The name of an existing Persistent Volume to bind to. This bypasses dynamic provisioning. | `""` |
 | `persistence.matchLabels` | Label selectors to apply when binding to an existing Persistent Volume. | `{}` |
 | `persistence.matchExpressions` | Expression selectors to apply when binding to an existing Persistent Volume. | `{}` |
+| `persistence.annotations` | Annotations to add to the PVC. | `{}` |
 | `additionalVolumes` | Additional volumes to be mounted in the home assistant container | `[]` |
 | `additionalMounts` | Additional volume mounts to be mounted in the home assistant container | `[]` |
 | `initContainers` | List of initialization containers | `[]` |
@@ -150,6 +151,18 @@ persistence:
     - key: "failure-domain.beta.kubernetes.io/zone"
       operator: "In"
       values: ["us-west-1a"]
+```
+
+### PVC Annotations
+
+You can add annotations to the PVC by specifying them in the `persistence.annotations` field. This is useful for backup solutions like k8up that use annotations to identify resources for backup.
+
+```yaml
+persistence:
+  enabled: true
+  annotations:
+    k8up.io/backup: "true"
+    another-annotation: "value"
 ```
 
 > **Note**: When specifying an `existingVolume`, ensure that the PV is not already bound to another PVC, as a PV can only be bound to a single PVC at a time.

--- a/charts/home-assistant/ci/persistence-enabled-values.yaml
+++ b/charts/home-assistant/ci/persistence-enabled-values.yaml
@@ -1,3 +1,6 @@
 persistence:
   enabled: true
   size: "10Gi"
+  annotations:
+    backup: "true"
+    second-annotation: "another value"

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -187,6 +187,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: {{ include "home-assistant.fullname" . }}
+      {{- with .Values.persistence.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       accessModes:
         - {{ .Values.persistence.accessMode }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -277,7 +277,7 @@ configuration:
 # Persistence values for the Home Assistant instance
 persistence:
   # Enable or disable persistence
-  enabled: true
+  enabled: false
   # Access mode for the persistent volume claim
   accessMode: ReadWriteOnce
   # Size of the persistent volume claim
@@ -287,9 +287,9 @@ persistence:
   # Name of the existing volume claim for the stateful set, this option can be used to use existing volumes
   existingVolume: ""
   # Annotations to add to the persistent volume claim
-  annotations:
-    k8up.io/backup: "true"
-    another-annotation: "value"
+  annotations: {}
+  #  k8up.io/backup: "true"
+  #  another-annotation: "value"
   ## Persistent Volume selectors
   ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
   matchLabels: {}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -277,7 +277,7 @@ configuration:
 # Persistence values for the Home Assistant instance
 persistence:
   # Enable or disable persistence
-  enabled: false
+  enabled: true
   # Access mode for the persistent volume claim
   accessMode: ReadWriteOnce
   # Size of the persistent volume claim
@@ -286,6 +286,10 @@ persistence:
   storageClass: ""
   # Name of the existing volume claim for the stateful set, this option can be used to use existing volumes
   existingVolume: ""
+  # Annotations to add to the persistent volume claim
+  annotations:
+    k8up.io/backup: "true"
+    another-annotation: "value"
   ## Persistent Volume selectors
   ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
   matchLabels: {}


### PR DESCRIPTION
This PR adds the ability to specify annotations for Persistent Volume Claims (PVCs) in the Home Assistant Helm chart, which enables integration with backup solutions like k8up.io that identify resources for backup via annotations.

### Changes made:
- Added annotations field with documentation to the persistence section in `values.yaml`
- Modified `statefulset.yaml` to apply these annotations to the PVC when it's created
- Updated `README.md` with documentation and usage examples for the new feature

### Example usage:
```yaml
persistence:
  enabled: true
  size: 5Gi
  annotations:
    k8up.io/backup: "true"
    another-annotation: "value"
```
This enhancement is backward compatible and adds flexibility for users who want to integrate their Home Assistant deployments with backup solutions or other systems that rely on PVC annotations.