### PR TITLE
feat: add matter-server as an addon

### DIFF
--- a/charts/home-assistant/templates/configmap-hass-config.yaml
+++ b/charts/home-assistant/templates/configmap-hass-config.yaml
@@ -3,7 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hass-configuration
-  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "home-assistant.labels" . | nindent 4 }}
 data:
   configuration.yaml: |
     {{- tpl .Values.configuration.templateConfig . | nindent 4 }}

--- a/charts/home-assistant/templates/configmap-init-script.yaml
+++ b/charts/home-assistant/templates/configmap-init-script.yaml
@@ -3,7 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: init-script
-  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "home-assistant.labels" . | nindent 4 }}
 data:
   init.sh: |
     {{- tpl .Values.configuration.initScript . | nindent 4 }}

--- a/charts/home-assistant/templates/service-matterserver.yaml
+++ b/charts/home-assistant/templates/service-matterserver.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.addons.codeserver.enabled  -}}
+{{- if and .Values.addons.matterserver.enabled  -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/home-assistant/templates/service-matterserver.yaml
+++ b/charts/home-assistant/templates/service-matterserver.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.addons.codeserver.enabled  -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "home-assistant.fullname" . }}-matterserver
+  labels:
+    {{- include "home-assistant.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.addons.matterserver.service.type }}
+  ports:
+    - port: {{ .Values.addons.matterserver.service.port }}
+      targetPort: matterserver
+      protocol: TCP
+      name: matterserver
+  selector:
+    {{- include "home-assistant.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
     {{- if .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
     {{- end }}
       containers:
@@ -119,6 +119,40 @@ spec:
             name: {{ include "home-assistant.fullname" . }}
           {{- if .Values.addons.codeserver.additionalMounts }}
             {{- .Values.addons.codeserver.additionalMounts | toYaml | nindent 10 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.addons.matterserver.enabled }}
+        - name: matterserver
+          securityContext:
+            {{- toYaml .Values.addons.matterserver.securityContext | nindent 12 }}
+          image: "{{ .Values.addons.matterserver.image.repository }}:{{ .Values.addons.matterserver.image.tag }}"
+          imagePullPolicy: "{{ .Values.addons.matterserver.image.pullPolicy }}"
+          ports:
+          - containerPort: 5580
+            name: matterserver
+            protocol: TCP
+          {{- with .Values.addons.matterserver.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.addons.matterserver.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.addons.matterserver.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.addons.matterserver.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - mountPath: /data
+            name: {{ include "home-assistant.fullname" . }}
+            subPath: matterserver
+          {{- if .Values.addons.matterserver.additionalMounts }}
+            {{- .Values.addons.matterserver.additionalMounts | toYaml | nindent 10 }}
           {{- end }}
         {{- end }}
       {{- if or (.Values.configuration.enabled) .Values.initContainers }}
@@ -218,4 +252,4 @@ spec:
       storageClassName: {{ .Values.persistence.storageClass }}
       {{- end }}
   {{- end }}
-  
+

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -408,6 +408,60 @@ addons:
     additionalMounts: []
       # - mountPath: /home/coder/.ssh/id_rsa
       #   name: id-rsa
+  matterserver:
+    # Enable or disable the matter-server addon
+    enabled: false
+    # Resource settings for the matter-server container
+    resources: {}
+    # Image settings for the code-server addon
+    image:
+      # Repository for the code-server image
+      repository: ghcr.io/home-assistant-libs/python-matter-server
+      # Image pull policy for the code-server image
+      pullPolicy: IfNotPresent
+      # Tag for the code-server image
+      tag: "7.0.1"
+    # Service settings
+    service:
+      # Service type (ClusterIP, NodePort, LoadBalancer, or ExternalName)
+      type: ClusterIP
+      # Service port
+      port: 5580
+    # if you need any additional volume mounts, you can define them here
+    additionalMounts: []
+      # - mountPath: /home/coder/.ssh/id_rsa
+      #   name: id-rsa
+
+    # Container security context settings
+    securityContext:
+      {}
+      # capabilities:
+      #   drop:
+      #   - ALL
+      # readOnlyRootFilesystem: true
+      # runAsNonRoot: true
+      # runAsUser: 1000
+
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /
+        port: matterserver
+        scheme: HTTP
+      periodSeconds: 20
+      successThreshold: 1
+      timeoutSeconds: 2
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /
+        port: matterserver
+        scheme: HTTP
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    startupProbe: {}
+
 
 # Annotations to add to the stateful set
 statefulSetAnnotations: {}


### PR DESCRIPTION
This allows to run [python-matter-server](https://github.com/home-assistant-libs/python-matter-server) as an add-on in the home assistant pod.

Although this can of course lead to scaling problems, I decided to expand the pod anyway. This means that it is not necessary to adjust the Home Assistant configuration (as localhost is used by default to communicate with the matter server), and there is no need to use another PVC.