### PR TITLE
feat: support configurable controller types and persistence strategies

### DIFF
--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -352,3 +352,21 @@ This allows for dynamic configuration based on your Helm values.
 
 To enable the code-server addon, set `addons.codeserver.enabled` to `true`. In addition, you can specify the `addons.codeserver.resources` values. The default value is `{}`.
 To be able to access the code-server addon, you need to enable the ingress for the code-server addon by setting `addons.codeserver.ingress.enabled` to `true` or setting `service.type` to `NodePort` or `LoadBalancer`.
+
+## Upgrade Notes (v0.3)
+
+This release adds support for both `StatefulSet` (default/legacy) and `Deployment` controllers, and clarifies persistence usage.
+
+### Key Changes
+- New value: `controller.type`—default remains `StatefulSet` for backward compatibility; use `Deployment` by setting `controller.type: Deployment`.
+- The auto-generated PVC for `controller.type: Deployment` is now named `<fullname>-pvc` (vs. prior defaults for StatefulSet). Update all references if switching controller type!
+- `persistence.existingClaim` is only supported with Deployment; `persistence.existingVolume` with StatefulSet.
+- Manual cleanup may be needed if switching controller kind (e.g. legacy StatefulSet/PVC may remain until manually deleted).
+
+### Migration Guidance
+- If you keep using StatefulSet, no changes required.
+- If switching to Deployment:
+  - Update any automation or manifests to refer to the new PVC name (`-pvc` suffix).
+  - Review and clean up old StatefulSet/volume resources as needed after migration.
+
+See "Controller Type" and "Persistence" sections above for full explanation.

--- a/charts/home-assistant/ci/deployment-controller-values.yaml
+++ b/charts/home-assistant/ci/deployment-controller-values.yaml
@@ -1,0 +1,12 @@
+# Test values for using Deployment instead of StatefulSet
+controller:
+  type: Deployment
+
+# Enable persistence to test PVC creation
+persistence:
+  enabled: true
+  size: 1Gi
+
+# Add some deployment annotations
+deploymentAnnotations:
+  test: "true"

--- a/charts/home-assistant/ci/statefulset-existing-volume-values.yaml
+++ b/charts/home-assistant/ci/statefulset-existing-volume-values.yaml
@@ -1,0 +1,9 @@
+# Test values for StatefulSet with an existing volume
+controller:
+  type: StatefulSet
+
+# Enable persistence and specify an existing volume
+persistence:
+  enabled: true
+  size: 1Gi
+  existingVolume: "existing-home-assistant-volume"

--- a/charts/home-assistant/ci/statefulset-existing-volume-values.yaml
+++ b/charts/home-assistant/ci/statefulset-existing-volume-values.yaml
@@ -1,9 +1,0 @@
-# Test values for StatefulSet with an existing volume
-controller:
-  type: StatefulSet
-
-# Enable persistence and specify an existing volume
-persistence:
-  enabled: true
-  size: 1Gi
-  existingVolume: "existing-home-assistant-volume"

--- a/charts/home-assistant/ci/statefulset-persistence-values.yaml
+++ b/charts/home-assistant/ci/statefulset-persistence-values.yaml
@@ -1,0 +1,8 @@
+# Test values for StatefulSet with persistence
+controller:
+  type: StatefulSet
+
+# Enable persistence
+persistence:
+  enabled: true
+  size: 1Gi

--- a/charts/home-assistant/templates/_helpers.tpl
+++ b/charts/home-assistant/templates/_helpers.tpl
@@ -69,3 +69,12 @@ Validate ingress configuration
 {{- fail "ingress.enabled and ingress.external cannot both be true" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate controller type
+*/}}
+{{- define "home-assistant.validateController" -}}
+{{- if not (or (eq .Values.controller.type "StatefulSet") (eq .Values.controller.type "Deployment")) -}}
+{{- fail "controller.type must be either 'StatefulSet' or 'Deployment'" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -1,17 +1,15 @@
-{{- include "home-assistant.validateController" . }}
-{{- if eq .Values.controller.type "StatefulSet" }}
+{{- if eq .Values.controller.type "Deployment" }}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "home-assistant.fullname" . }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
-{{- if .Values.statefulSetAnnotations }}
+{{- if .Values.deploymentAnnotations }}
   annotations:
-    {{- toYaml .Values.statefulSetAnnotations | nindent 4 }}
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
 {{- end }}
 spec:
-  serviceName: {{ include "home-assistant.fullname" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -184,42 +182,16 @@ spec:
       {{- if not .Values.persistence.enabled }}
       - name: {{ include "home-assistant.fullname" . }}
         emptyDir: {}
+      {{- else if .Values.persistence.existingClaim }}
+      - name: {{ include "home-assistant.fullname" . }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim }}
+      {{- else }}
+      - name: {{ include "home-assistant.fullname" . }}
+        persistentVolumeClaim:
+          claimName: {{ include "home-assistant.fullname" . }}
       {{- end }}
       {{- if .Values.additionalVolumes }}
         {{- .Values.additionalVolumes | toYaml | nindent 6 }}
       {{- end }}
-  {{- if .Values.persistence.enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: {{ include "home-assistant.fullname" . }}
-      {{- with .Values.persistence.annotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    spec:
-      accessModes:
-        - {{ .Values.persistence.accessMode }}
-      {{- if .Values.persistence.existingVolume }}
-      volumeName: {{ .Values.persistence.existingVolume }}
-      {{- end }}
-      {{- if or .Values.persistence.matchLabels (.Values.persistence.matchExpressions) }}
-      selector:
-      {{- if .Values.persistence.matchLabels }}
-        matchLabels:
-        {{ toYaml .Values.persistence.matchLabels | indent 8 }}
-      {{- end -}}
-      {{- if .Values.persistence.matchExpressions }}
-        matchExpressions:
-          {{ toYaml .Values.persistence.matchExpressions | indent 8 }}
-        {{- end -}}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.size }}
-      {{- if .Values.persistence.storageClass }}
-      storageClassName: {{ .Values.persistence.storageClass }}
-      {{- end }}
-
-  {{- end }}
 {{- end }}
-

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if eq .Values.controller.type "Deployment" }}
+{{- include "home-assistant.validateController" . | trim }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,7 +87,7 @@ spec:
           {{- end }}
           volumeMounts:
           - mountPath: /config
-            name: {{ include "home-assistant.fullname" . }}
+            name: {{ include "home-assistant.fullname" . }}-pvc
           {{- if .Values.additionalMounts }}
             {{- .Values.additionalMounts | toYaml | nindent 10 }}
           {{- end }}
@@ -116,7 +117,7 @@ spec:
           {{- end }}
           volumeMounts:
           - mountPath: /config
-            name: {{ include "home-assistant.fullname" . }}
+            name: {{ include "home-assistant.fullname" . }}-pvc
           {{- if .Values.addons.codeserver.additionalMounts }}
             {{- .Values.addons.codeserver.additionalMounts | toYaml | nindent 10 }}
           {{- end }}
@@ -141,7 +142,7 @@ spec:
           {{- end }}
           {{- if .Values.configuration.initContainer.env }}
           env:
-            {{- toYaml .env | nindent 12 }}
+            {{- toYaml .Values.configuration.initContainer.env | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- range .Values.configuration.initContainer.volumeMounts }}
@@ -180,17 +181,17 @@ spec:
           name: hass-configuration
       {{- end }}
       {{- if not .Values.persistence.enabled }}
-      - name: {{ include "home-assistant.fullname" . }}
+      - name: {{ include "home-assistant.fullname" . }}-pvc
         emptyDir: {}
-      {{- else if .Values.persistence.existingClaim }}
-      - name: {{ include "home-assistant.fullname" . }}
+    {{- else if .Values.persistence.existingClaim }}
+      - name: {{ include "home-assistant.fullname" . }}-pvc
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
-      {{- else }}
-      - name: {{ include "home-assistant.fullname" . }}
+    {{- else }}
+      - name: {{ include "home-assistant.fullname" . }}-pvc
         persistentVolumeClaim:
-          claimName: {{ include "home-assistant.fullname" . }}
-      {{- end }}
+          claimName: {{ include "home-assistant.fullname" . }}-pvc
+    {{- end }}
       {{- if .Values.additionalVolumes }}
         {{- .Values.additionalVolumes | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/home-assistant/templates/pvc.yaml
+++ b/charts/home-assistant/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "home-assistant.fullname" . }}
+  name: {{ include "home-assistant.fullname" . }}-pvc
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
   {{- with .Values.persistence.annotations }}

--- a/charts/home-assistant/templates/pvc.yaml
+++ b/charts/home-assistant/templates/pvc.yaml
@@ -1,0 +1,35 @@
+{{- if and (eq .Values.controller.type "Deployment") .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "home-assistant.fullname" . }}
+  labels:
+    {{- include "home-assistant.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.existingVolume }}
+  volumeName: {{ .Values.persistence.existingVolume }}
+  {{- end }}
+  {{- if or .Values.persistence.matchLabels (.Values.persistence.matchExpressions) }}
+  selector:
+  {{- if .Values.persistence.matchLabels }}
+    matchLabels:
+    {{ toYaml .Values.persistence.matchLabels | indent 4 }}
+  {{- end -}}
+  {{- if .Values.persistence.matchExpressions }}
+    matchExpressions:
+      {{ toYaml .Values.persistence.matchExpressions | indent 4 }}
+    {{- end -}}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -287,8 +287,10 @@ persistence:
   size: 5Gi
   # Storage class for the persistent volume claim
   storageClass: ""
-  # Name of the existing volume claim for the stateful set, this option can be used to use existing volumes
+  # Name of the existing volume for the StatefulSet, this option can be used to bind to an existing PV
   existingVolume: ""
+  # Name of the existing PVC to use with Deployment, this option can be used to use an existing PVC
+  existingClaim: ""
   # Annotations to add to the persistent volume claim
   annotations: {}
   #  k8up.io/backup: "true"
@@ -409,5 +411,13 @@ addons:
       # - mountPath: /home/coder/.ssh/id_rsa
       #   name: id-rsa
 
+# Controller configuration
+controller:
+  # Type of controller to use: StatefulSet or Deployment
+  type: StatefulSet
+
 # Annotations to add to the stateful set
 statefulSetAnnotations: {}
+
+# Annotations to add to the deployment
+deploymentAnnotations: {}


### PR DESCRIPTION
- Add support for choosing between StatefulSet and Deployment as controller types.
- Introduce documentation and configuration options for using an existing PVC with Deployment or an existing PV with StatefulSet.
- Add new values and documentation for deploymentAnnotations.
- Provide detailed documentation on controller types and persistence strategies.
- Add new Helm template files for Deployment controller and corresponding PersistentVolumeClaim management.
- Update test value files to cover various storage scenarios for both controller types.
- Add controller type validation logic to helpers.