### PR TITLE
fix: config volume mount name on the deployment init container did not contain `-pvc` suffix

### DIFF
--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -153,7 +153,7 @@ spec:
               {{ end }}
             {{- end }}
             - mountPath: /config
-              name: {{ include "home-assistant.fullname" $ }}
+              name: {{ include "home-assistant.fullname" $ }}-pvc
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
When creating a new deployment with the following values:
```yaml
controller:
  type: Deployment
persistence:
  enabled: true
```
Because the PVC that is created contains the `-pvc` suffix, the init container was failing on startup due to the volume name not existing.