### PR TITLE
Switch deployment template variable to use current context instead of root context

### DIFF
--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -153,7 +153,7 @@ spec:
               {{ end }}
             {{- end }}
             - mountPath: /config
-              name: {{ include "home-assistant.fullname" $ }}-pvc
+              name: {{ include "home-assistant.fullname" . }}-pvc
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
With the root context `$` the chart fails to build with error:
```
Deployment.apps "home-assistant" is invalid:
  spec.template.spec.initContainers[0].volumeMounts[2].name: Not found: "home-assistant"
```

This change aligns this template variable with other usages of `{{ include "home-assistant.fullname" . }}` in the file.