### PR TITLE
feat: allow deployment strategy configuration

### DIFF
--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
   selector:
     matchLabels:
       {{- include "home-assistant.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
   template:
     metadata:
       labels:

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -437,3 +437,6 @@ statefulSetAnnotations: {}
 
 # Annotations to add to the deployment
 deploymentAnnotations: {}
+
+# Deployment strategy type (RollingUpdate, Recreate)
+deploymentStrategy: RollingUpdate


### PR DESCRIPTION
This PR enables the user to configure the Deployment strategy type. I have set the value in `values.yaml` to be in line with the K8s default of `RollingUpdate`.