### PR TITLE
feat: allow deployment of extra objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `addons.codeserver.ingress.hosts` | Hosts for the code-server addon | `[]` |
 | `addons.codeserver.ingress.tls` | TLS settings for the code-server addon | `[]` |
 | `addons.codeserver.ingress.annotations` | Annotations for the code-server addon | `{}` |
+| `extraObjects` | List of extra Kubernetes resources to create alongside the Home Assistant deployment | `[]` |
 
 ## Controller Type
 

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -113,6 +113,7 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `addons.codeserver.ingress.hosts` | Hosts for the code-server addon | `[]` |
 | `addons.codeserver.ingress.tls` | TLS settings for the code-server addon | `[]` |
 | `addons.codeserver.ingress.annotations` | Annotations for the code-server addon | `{}` |
+| `extraObjects` | List of extra Kubernetes resources to create alongside the Home Assistant deployment | `[]` |
 
 ## Controller Type
 
@@ -292,6 +293,33 @@ additionalMounts:
 ```
 
 Note: When mounting usb devices, you need to set the `securityContext.privileged` value to `true`.
+
+## Extra Objects
+
+The `extraObjects` parameter allows you to create additional Kubernetes resources alongside your Home Assistant deployment. This is useful for creating ConfigMaps, Secrets and other resources that your setup might need while still managing them through the Helm chart.
+
+Example usage:
+
+```yaml
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "home-assistant.fullname" . }}-custom-config
+    data:
+      custom.yaml: |
+        setting1: value1
+        setting2: value2
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: my-api-keys
+    type: Opaque
+    stringData:
+      api-key: "api-key"
+      mqtt-password: "password"
+```
 
 ## Advanced Configuration
 

--- a/charts/home-assistant/ci/extra-objects-values.yaml
+++ b/charts/home-assistant/ci/extra-objects-values.yaml
@@ -1,0 +1,31 @@
+# Test values for extra objects
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "home-assistant.fullname" . }}-extra-config
+    data:
+      custom-config: |
+        test: value
+        environment: ci
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-extra-secret
+    type: Opaque
+    stringData:
+      api-key: test-api-key
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-extra-service
+    spec:
+      type: ClusterIP
+      ports:
+        - port: 8123
+          targetPort: 8123
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: home-assistant
+        app.kubernetes.io/instance: test-release

--- a/charts/home-assistant/templates/extra-objects.yaml
+++ b/charts/home-assistant/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (ternary . (toYaml .) (typeIs "string" .)) $ }}
+{{ end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -440,3 +440,6 @@ deploymentAnnotations: {}
 
 # Deployment strategy type (RollingUpdate, Recreate)
 deploymentStrategy: RollingUpdate
+
+# Extra objects to create
+extraObjects: []


### PR DESCRIPTION
# Changes
- Add `extraObjects` parameter to allow dynamic creation of custom Kubernetes resources

# Motivation
This is a tiny QoL improvement, allowing management of resources that are strictly tied to HA within the same helm release. This is a common pattern found in many Helm charts, for example:
- [`traefik-helm-chart`](https://github.com/traefik/traefik-helm-chart/blob/9db9fc6d76f8d530359cfc0a2b41a57b8978559e/traefik/values.yaml#L960-L965)
- [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/blob/76b2a7a3023658ec28341c72db8e7dd869508481/charts/kube-prometheus-stack/values.yaml#L5372-L5397)
- [`zigbee2mqtt-chart`](https://github.com/Koenkk/zigbee2mqtt-chart/blob/5e2bf6ebe6e00509119ddf4d11d5d21d589e1f27/charts/zigbee2mqtt/values.yaml#L271-L281)
