### PR TITLE
fix: init-script duplicating configuration.yaml header comment

### DIFF
--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -242,7 +242,7 @@ configuration:
         cat /config-templates/configuration.yaml > /config/configuration.yaml
       else
         # Perform the merge operation if /config/configuration.yaml is not empty
-        yq eval-all --inplace 'select(fileIndex == 0) *d select(fileIndex == 1)' /config/configuration.yaml /config-templates/configuration.yaml
+        yq eval-all --inplace --header-preprocess=false 'select(fileIndex == 0) *d select(fileIndex == 1)' /config/configuration.yaml /config-templates/configuration.yaml
       fi
     fi
 


### PR DESCRIPTION
The header at the top of configuration.yaml

```yml
# Loads default set of integrations. Do not remove.
```

gets duplicated every time the pod restarts when using `forceInit`.

This change prevents the duplication, as per this minimal example:

```bash
$ cat /config/configuration.yaml
# header comment
a: b
# another comment
c: d

$ cat /config-templates/configuration.yaml
# header comment
a: b
c: e
f: g

$ yq eval-all --header-preprocess=false 'select(fileIndex == 0) *d select(fileIndex == 1)' /config/configuration.yaml /config-templates/configuration.yaml
# header comment
a: b
# another comment
c: e
f: g
```