### PR TITLE
Add support for additional ingresses

### DIFF
--- a/charts/home-assistant/ci/additional-ingresses-values.yaml
+++ b/charts/home-assistant/ci/additional-ingresses-values.yaml
@@ -1,0 +1,46 @@
+# Test configuration for additionalIngresses feature
+
+additionalPorts:
+  - name: dlna
+    containerPort: 5555
+    protocol: TCP
+
+additionalServices:
+  - name: dlna
+    port: 5555
+    targetPort: dlna
+    type: ClusterIP
+    protocol: TCP
+
+additionalIngresses:
+  # Test 1: Path-only routing (no host) for DLNA
+  - name: dlna
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    rules:
+      - paths:
+          - path: /notify
+            pathType: Prefix
+            serviceName: home-assistant-dlna
+            servicePort: 5555
+
+  # Test 2: IoT API endpoint with custom host
+  - name: iot-api
+    className: nginx
+    rules:
+      - host: iot.example.local
+        paths:
+          - path: /api/
+            pathType: Prefix
+
+  # Test 3: Alternative domain with TLS
+  - name: alt-domain
+    rules:
+      - host: ha-alt.example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: ha-alt-tls
+        hosts:
+          - ha-alt.example.local

--- a/charts/home-assistant/templates/ingress-additional.yaml
+++ b/charts/home-assistant/templates/ingress-additional.yaml
@@ -1,0 +1,72 @@
+{{- range .Values.additionalIngresses }}
+{{- $fullName := include "home-assistant.fullname" $ }}
+{{- $ingressName := printf "%s-%s" $fullName .name }}
+{{- $defaultSvcPort := $.Values.service.port }}
+{{- if and .className (not (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if and .annotations (not (hasKey .annotations "kubernetes.io/ingress.class")) }}
+  {{- $_ := set .annotations "kubernetes.io/ingress.class" .className }}
+  {{- end }}
+{{- end }}
+---
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $ingressName }}
+  labels:
+    {{- include "home-assistant.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .className }}
+  {{- end }}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .rules }}
+    {{- if .host }}
+    - host: {{ .host | quote }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- $svcName := default $fullName .serviceName }}
+              {{- $svcPort := default $defaultSvcPort .servicePort }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $svcName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -132,6 +132,22 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Additional ingresses for exposing Home Assistant on different paths/hosts
+# Useful for IoT devices that don't support TLS or need specific path routing
+additionalIngresses: []
+#  - name: dlna
+#    className: ""
+#    labels: {}
+#    annotations: {}
+#    rules:
+#      - host: ""  # Optional: omit for path-only routing
+#        paths:
+#          - path: /notify
+#            pathType: Prefix
+#            serviceName: ""  # Optional: defaults to main HA service
+#            servicePort: ""  # Optional: defaults to service.port
+#    tls: []
+
 # Resource settings for the container
 resources:
   {}


### PR DESCRIPTION
## Summary

Adds `additionalIngresses` configuration option to define multiple additional Kubernetes Ingress resources, following the existing `additionalServices` pattern.

- Optional host field for path-only routing (useful for DLNA devices)
- Configurable service/port per path (defaults to main HA service)
- Full Kubernetes version compatibility (1.14+, 1.18+, 1.19+)
- Support for className, labels, annotations, and TLS

Closes #109

## Example Usage

```yaml
additionalIngresses:
  # Path-only routing (no host) for DLNA devices
  - name: dlna
    annotations:
      nginx.ingress.kubernetes.io/ssl-redirect: "false"
    rules:
      - paths:
          - path: /notify
            pathType: Prefix
            serviceName: home-assistant-dlna
            servicePort: 5555

  # IoT device webhook endpoint
  - name: iot-webhook
    className: nginx
    rules:
      - host: iot.example.local
        paths:
          - path: /api/webhook
            pathType: Prefix
```

## Test plan

- [x] Helm lint passes
- [x] Template renders correctly with test values
- [x] Empty `additionalIngresses` produces no output
- [x] Kubernetes version compatibility verified (1.17 uses v1beta1, current uses v1)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)