### PR TITLE
Add podReplacementPolicy support for StatefulSet

### DIFF
--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
 spec:
   serviceName: {{ include "home-assistant.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.podReplacementPolicy }}
+  podReplacementPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "home-assistant.selectorLabels" . | nindent 6 }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -462,6 +462,13 @@ controller:
 # Annotations to add to the stateful set
 statefulSetAnnotations: {}
 
+# Pod replacement policy for the StatefulSet (requires Kubernetes 1.32+)
+# When set to "Always", a replacement pod is created immediately when a pod is terminating
+# (e.g., due to a node failure), rather than waiting for the terminating pod to fully shut down.
+# Valid values: "" (default Kubernetes behavior), "Always"
+# https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-replacement-policy
+podReplacementPolicy: ""
+
 # Annotations to add to the deployment
 deploymentAnnotations: {}
 


### PR DESCRIPTION
## Summary

- Adds a `podReplacementPolicy` value that renders in the StatefulSet spec when set
- Defaults to `""` (empty string), preserving existing behavior
- When set to `"Always"`, the StatefulSet controller immediately creates a replacement pod when a pod enters the Terminating state (e.g., due to node failure)

## Motivation

When running Home Assistant as a StatefulSet and a node fails, the pod can get stuck in `Terminating` state indefinitely. Without `podReplacementPolicy: Always`, the StatefulSet controller waits for the terminating pod to be fully removed before creating a replacement — which may never happen if the node is unreachable.

This is a [Kubernetes 1.32+ feature](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-replacement-policy) that graduated to stable in v1.32.

## Changes

- **`templates/statefulset.yaml`**: Conditionally renders `podReplacementPolicy` in the StatefulSet spec
- **`values.yaml`**: Adds `podReplacementPolicy` with documentation and a link to the Kubernetes docs

## Usage

```yaml
podReplacementPolicy: "Always"
```