### PR TITLE
Automatically enable Prometheus integration.

### DIFF
--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -397,7 +397,8 @@ startupProbe: {}
   #   port: http
 
 serviceMonitor:
-  # requires HA integration:  https://www.home-assistant.io/integrations/prometheus/
+  # Enabling this automatically enables the Prometheus integration with default configuration.
+  # See https://www.home-assistant.io/integrations/prometheus/ for details.
   enabled: false
   scrapeInterval: 30s
   labels: {}


### PR DESCRIPTION
Automatically enable Prometheus integration when `serviceMonitor.enabled` is `true`.