### PR TITLE
fix: remove labels from StatefulSet volumeClaimTemplates

### DIFF
--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -219,8 +219,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: {{ include "home-assistant.fullname" . }}
-      labels:
-        {{- include "home-assistant.labels" . | nindent 8 }}
       {{- with .Values.persistence.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

- Removes labels from `volumeClaimTemplates` metadata in StatefulSet template, fixing helm upgrade failures for existing deployments

## Root Cause

PR #160 added `home-assistant.labels` to `volumeClaimTemplates` metadata. This includes version-dependent labels (`helm.sh/chart`, `app.kubernetes.io/version`) that change on every chart or app version bump. Kubernetes forbids any modifications to `volumeClaimTemplates` after StatefulSet creation, so every upgrade fails with:

> Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden

## Fix

Remove the labels block from `volumeClaimTemplates` entirely, restoring pre-0.3.48 behavior. All other changes from PR #160 (controller labels, pod labels, commonLabels on other resources) remain intact.

Fixes #167

## Test plan

- [x] All 25 CI value files template successfully with `helm template`
- [x] `helm lint` passes for default and persistence-enabled values
- [x] VCT renders correctly without labels (verified output)
- [x] Annotations on VCT still render correctly