### PR TITLE
feat: serviceMonitor and prometheus config changes

### DIFF
--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -316,6 +316,8 @@ If you have the Prometheus Operator installed, you can enable a ServiceMonitor t
 ```yaml
 serviceMonitor:
   enabled: true
+  # Set custom namespace for serviceMonitor resource deployment (optional)
+  namespace: "monitoring"
   scrapeInterval: 30s
   labels:
     release: prometheus

--- a/charts/home-assistant/templates/service-monitor.yaml
+++ b/charts/home-assistant/templates/service-monitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "home-assistant.fullname" . }}
+  {{- if not .Values.serviceMonitor.customNamespace }}
   namespace: {{ include "home-assistant.namespace" . }}
+  {{- else }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
   labels:
     {{- include "home-assistant.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}

--- a/charts/home-assistant/templates/service-monitor.yaml
+++ b/charts/home-assistant/templates/service-monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "home-assistant.fullname" . }}
-  {{- if not .Values.serviceMonitor.customNamespace }}
+  {{- if not .Values.serviceMonitor.namespace }}
   namespace: {{ include "home-assistant.namespace" . }}
   {{- else }}
   namespace: {{ .Values.serviceMonitor.namespace }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -222,6 +222,13 @@ configuration:
 
     {{- if .Values.serviceMonitor.enabled }}
     prometheus:
+    {{- if or 
+      (not .Values.serviceMonitor.bearerToken)
+      (not .Values.serviceMonitor.bearerToken.secretName)
+      (not .Values.serviceMonitor.bearerToken.secretKey) 
+    }}
+      requires_auth: false
+    {{- end }}
     {{- end }}
 
     {{- if or .Values.ingress.enabled .Values.ingress.external }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -407,6 +407,8 @@ serviceMonitor:
   # Enabling this automatically enables the Prometheus integration with default configuration.
   # See https://www.home-assistant.io/integrations/prometheus/ for details.
   enabled: false
+  # Set custom namespace for serviceMonitor resource deployment
+  # customNamespace: ""
   scrapeInterval: 30s
   labels: {}
   # Bearer token authentication configuration

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -415,7 +415,7 @@ serviceMonitor:
   # See https://www.home-assistant.io/integrations/prometheus/ for details.
   enabled: false
   # Set custom namespace for serviceMonitor resource deployment
-  # customNamespace: ""
+  # namespace: ""
   scrapeInterval: 30s
   labels: {}
   # Bearer token authentication configuration

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -222,10 +222,10 @@ configuration:
 
     {{- if .Values.serviceMonitor.enabled }}
     prometheus:
-    {{- if or 
+    {{- if or
       (not .Values.serviceMonitor.bearerToken)
       (not .Values.serviceMonitor.bearerToken.secretName)
-      (not .Values.serviceMonitor.bearerToken.secretKey) 
+      (not .Values.serviceMonitor.bearerToken.secretKey)
     }}
       requires_auth: false
     {{- end }}


### PR DESCRIPTION
# Description

When I deployed HA using this Helm chart, I wanted to ensure that my Prometheus would scrape metrics provided by HA using *serviceMonitor* CRD. The first challenge was to change namespace, where *serviceMonitor* object will be deployed. Then, the next challenge was to enable scrapping without required auth (I am on my home network with disabled internet access, no security risks).

# Changes

* added new parameter `serviceMonitor.namespace`
  * when this parameter is defined and is not empty, the provided namespace will be used instead of deployment's one
* prometheus auth is disabled on HA (`prometheus.requires_auth: false`) when `configuration.enabled` is set to `true` and no bearer token is set.

# Tests

- [x]  Documentation updated
- [x]  Tests performed locally
