### PR TITLE
feat: add Gateway API HTTPRoute support

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -17,4 +17,4 @@ sources:
 - https://github.com/cdr/code-server
 - https://github.com/pajikos/home-assistant-helm-chart/tree/main/charts/home-assistant
 type: application
-version: 0.3.64
+version: 0.3.65

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -17,4 +17,4 @@ sources:
 - https://github.com/cdr/code-server
 - https://github.com/pajikos/home-assistant-helm-chart/tree/main/charts/home-assistant
 type: application
-version: 0.3.65
+version: 0.3.64

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -83,6 +83,10 @@ This document provides detailed configuration options for the Home Assistant Hel
 | `ingress.enabled` | Enable ingress for Home Assistant | `false` |
 | `ingress.external` | Enable external ingress (cannot be true when ingress.enabled is true) | `false` |
 | `additionalIngresses` | List of additional ingress configurations | `[]` |
+| `httpRoute.enabled` | Enable Gateway API HTTPRoute for Home Assistant | `false` |
+| `httpRoute.parentRefs` | Parent Gateways the HTTPRoute attaches to | `[]` |
+| `httpRoute.hostnames` | Hostnames matched by the HTTPRoute | `[]` |
+| `httpRoute.matches` | Route match rules (defaults to a PathPrefix `/` match) | `[]` |
 | `resources` | Resource settings for the container | `{}` |
 | `nodeSelector` | Node selector settings for scheduling the pod on specific nodes | `{}` |
 | `tolerations` | Tolerations settings for scheduling the pod based on node taints | `[]` |
@@ -302,6 +306,44 @@ Each additional ingress supports:
     - `serviceName`: Target service (defaults to main Home Assistant service)
     - `servicePort`: Target port (defaults to `service.port`)
 - `tls`: TLS configuration (optional)
+
+## HTTPRoute (Gateway API)
+
+As an alternative to a traditional Ingress, the chart can expose Home Assistant
+through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. This
+requires the Gateway API CRDs and a Gateway controller to be installed in the
+cluster, and an existing `Gateway` to attach to.
+
+`httpRoute.enabled` is an independent toggle, so it can be used on its own or
+alongside `ingress.enabled` during a migration.
+
+Example configuration:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: example-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - home-assistant.example.com
+```
+
+The route forwards traffic to the main Home Assistant service on
+`service.port`. When `httpRoute.matches` is empty a single `PathPrefix: /`
+match is generated; set it to define custom path matching, for example:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: example-gateway
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+```
 
 ## HostPort and HostNetwork
 

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -344,6 +344,13 @@ httpRoute:
     - home-assistant.example.com
 ```
 
+`httpRoute.parentRefs` is required when `httpRoute.enabled` is `true`: the chart
+fails the render with a clear message if it is left empty, since a route with no
+`parentRefs` would not attach to any Gateway. Enabling `httpRoute` also emits the
+reverse-proxy `http:` block (`use_x_forwarded_for` / `trusted_proxies`) in the
+managed `configuration.yaml`, the same as `ingress`, so client IPs are handled
+correctly behind the Gateway.
+
 The route forwards traffic to the main Home Assistant service on
 `service.port`. When `httpRoute.matches` is empty a single `PathPrefix: /`
 match is generated; set it to define custom path matching, for example:
@@ -453,7 +460,7 @@ configuration:
     # Loads default set of integrations. Do not remove.
     default_config:
 
-    {{- if .Values.ingress.enabled }}
+    {{- if or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled }}
     http:
       use_x_forwarded_for: true
       trusted_proxies:

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -310,12 +310,26 @@ Each additional ingress supports:
 ## HTTPRoute (Gateway API)
 
 As an alternative to a traditional Ingress, the chart can expose Home Assistant
-through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. This
-requires the Gateway API CRDs and a Gateway controller to be installed in the
-cluster, and an existing `Gateway` to attach to.
+through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`.
 
-`httpRoute.enabled` is an independent toggle, so it can be used on its own or
-alongside `ingress.enabled` during a migration.
+`httpRoute.enabled` is an independent toggle (disabled by default), so it can be
+used on its own or alongside `ingress.enabled` during a migration.
+
+### Prerequisites
+
+This chart only renders an `HTTPRoute`; it does **not** bundle the Gateway API
+CRDs or a Gateway controller. Those are cluster infrastructure that must be
+installed separately before enabling `httpRoute`:
+
+1. Install the Gateway API CRDs, for example:
+
+   ```bash
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+   ```
+
+2. Install a Gateway controller (for example [Envoy Gateway](https://gateway.envoyproxy.io/),
+   NGINX Gateway Fabric, or Istio) and create a `Gateway` for the `HTTPRoute` to
+   attach to via `httpRoute.parentRefs`.
 
 Example configuration:
 

--- a/charts/home-assistant/templates/_helpers.tpl
+++ b/charts/home-assistant/templates/_helpers.tpl
@@ -106,6 +106,15 @@ Validate ingress configuration
 {{- end -}}
 
 {{/*
+Validate HTTPRoute configuration
+*/}}
+{{- define "home-assistant.validateHTTPRoute" -}}
+{{- if and .Values.httpRoute.enabled (not .Values.httpRoute.parentRefs) -}}
+{{- fail "httpRoute.enabled is true but httpRoute.parentRefs is empty; set at least one parentRef so the HTTPRoute attaches to a Gateway" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate controller type
 */}}
 {{- define "home-assistant.validateController" -}}

--- a/charts/home-assistant/templates/httproute.yaml
+++ b/charts/home-assistant/templates/httproute.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.httpRoute.enabled -}}
+{{- include "home-assistant.validateHTTPRoute" . -}}
 {{- $fullName := include "home-assistant.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/home-assistant/templates/httproute.yaml
+++ b/charts/home-assistant/templates/httproute.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "home-assistant.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "home-assistant.namespace" . }}
+  labels:
+    {{- include "home-assistant.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- with .Values.httpRoute.matches }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+{{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -143,6 +143,29 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Gateway API HTTPRoute settings (alternative to ingress)
+# Requires the Gateway API CRDs and a Gateway controller installed in the cluster
+httpRoute:
+  # Enable HTTPRoute for Home Assistant
+  enabled: false
+  # Labels to add to the HTTPRoute
+  labels: {}
+  # Annotations to add to the HTTPRoute
+  annotations: {}
+  # Parent Gateways this route attaches to (required when enabled)
+  parentRefs: []
+  #  - name: example-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # Hostnames matched by this route (optional; omit to match all)
+  hostnames: []
+  #  - home-assistant.example.com
+  # Route match rules (optional; defaults to a single PathPrefix "/" match)
+  matches: []
+  #  - path:
+  #      type: PathPrefix
+  #      value: /
+
 # Additional ingresses for exposing Home Assistant on different paths/hosts
 # Useful for IoT devices that don't support TLS or need specific path routing
 additionalIngresses: []

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -144,7 +144,8 @@ ingress:
   #      - chart-example.local
 
 # Gateway API HTTPRoute settings (alternative to ingress)
-# Requires the Gateway API CRDs and a Gateway controller installed in the cluster
+# This chart does not install the Gateway API CRDs or a Gateway controller;
+# both must already be present in the cluster (see the chart README).
 httpRoute:
   # Enable HTTPRoute for Home Assistant
   enabled: false

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -248,7 +248,7 @@ configuration:
     prometheus:
     {{- end }}
 
-    {{- if or .Values.ingress.enabled .Values.ingress.external }}
+    {{- if or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled }}
     http:
       use_x_forwarded_for: true
       trusted_proxies:


### PR DESCRIPTION
Adds an optional Gateway API `HTTPRoute` as an alternative to the existing Ingress, addressing #164. It is gated behind an independent `httpRoute.enabled` toggle, so it can be used on its own or alongside `ingress.enabled` during a migration. The route forwards to the main Home Assistant service on `service.port`, with passthrough `parentRefs` / `hostnames` and a default `PathPrefix: /` match that can be overridden via `httpRoute.matches`.

### Changes
- New `templates/httproute.yaml` mirroring `ingress.yaml` (reuses the existing `home-assistant.labels` / `.fullname` / `.namespace` helpers)
- New `httpRoute` block in `values.yaml`, disabled by default
- README: values-table rows + an "HTTPRoute (Gateway API)" section
- Chart version `0.3.62` -> `0.3.63`

### Validation
- `helm lint` passes
- `helm template` rendered for: default (route absent), enabled with `parentRefs`+`hostnames` (default `/` match), enabled with custom multi-match + labels/annotations, and `ingress.enabled` (no regression) — all produce valid manifests

### Note on CI
I did not add a `ci/` overlay. The `lint-test` kind cluster does not ship the Gateway API CRDs, so an `httpRoute.enabled=true` overlay would fail `ct install`. The feature is disabled by default (renders nothing in default CI) and was validated locally with `helm template`. Happy to add a Gateway-API-CRD install step + a `ci/httproute-values.yaml` overlay if you'd prefer that coverage.

related: #164