### PR TITLE
Add chart download stats dashboard

### DIFF
--- a/.github/scripts/chart_download_stats.py
+++ b/.github/scripts/chart_download_stats.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+import argparse
+import html
+import json
+import math
+import os
+import re
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ASSET_RE = re.compile(
+    r"^home-assistant-(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\.tgz$"
+)
+API_VERSION = "2022-11-28"
+TOP_VERSION_COUNT = 10
+
+
+def now_utc():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_semver(version):
+    core_and_build = version.split("+", 1)[0]
+    core, _, prerelease = core_and_build.partition("-")
+    major, minor, patch = [int(part) for part in core.split(".")]
+    prerelease_key = ()
+    if prerelease:
+        prerelease_key = tuple(parse_prerelease_part(part) for part in prerelease.split("."))
+    return major, minor, patch, 0 if prerelease else 1, prerelease_key
+
+
+def parse_prerelease_part(part):
+    if part.isdigit():
+        return 0, int(part)
+    return 1, part
+
+
+def compact_count(count):
+    if count < 1000:
+        return str(count)
+    if count < 1_000_000:
+        return f"{count // 1000}k"
+
+    value = math.floor(count / 100_000) / 10
+    if value.is_integer():
+        return f"{int(value)}M"
+    return f"{value:g}M"
+
+
+def build_stats(releases, generated_at=None):
+    versions = []
+
+    for release in releases:
+        tag_name = str(release.get("tag_name", ""))
+        for asset in release.get("assets") or []:
+            asset_name = str(asset.get("name", ""))
+            match = ASSET_RE.match(asset_name)
+            if not match:
+                continue
+
+            versions.append(
+                {
+                    "version": match.group("version"),
+                    "assetName": asset_name,
+                    "tagName": tag_name,
+                    "downloadCount": int(asset.get("download_count") or 0),
+                }
+            )
+
+    if not versions:
+        raise ValueError("No home-assistant chart archive assets found")
+
+    versions.sort(key=lambda item: parse_semver(item["version"]), reverse=True)
+    latest = versions[0]
+    top_versions = sorted(versions, key=lambda item: item["downloadCount"], reverse=True)[
+        :TOP_VERSION_COUNT
+    ]
+
+    return {
+        "generatedAt": generated_at or now_utc(),
+        "totalDownloads": sum(item["downloadCount"] for item in versions),
+        "releaseCount": len(versions),
+        "latestVersion": latest["version"],
+        "latestVersionDownloads": latest["downloadCount"],
+        "versions": versions,
+        "topVersions": [
+            {
+                "version": item["version"],
+                "downloadCount": item["downloadCount"],
+            }
+            for item in top_versions
+        ],
+    }
+
+
+def write_outputs(stats, output_dir):
+    stats_dir = Path(output_dir) / "stats"
+    stats_dir.mkdir(parents=True, exist_ok=True)
+
+    write_json(stats_dir / "downloads.json", stats)
+    write_json(stats_dir / "downloads-badge.json", build_badge(stats))
+    (stats_dir / "index.html").write_text(build_dashboard(stats), encoding="utf-8")
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def build_badge(stats):
+    return {
+        "schemaVersion": 1,
+        "label": "chart downloads",
+        "message": compact_count(stats["totalDownloads"]),
+        "color": "blue",
+    }
+
+
+def build_dashboard(stats):
+    rows = "\n".join(
+        build_version_row(version)
+        for version in stats["versions"]
+    )
+
+    generated_at = html.escape(stats["generatedAt"])
+    total_downloads = f"{stats['totalDownloads']:,}"
+    latest_version = html.escape(stats["latestVersion"])
+    latest_downloads = f"{stats['latestVersionDownloads']:,}"
+    release_count = f"{stats['releaseCount']:,}"
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Home Assistant Helm Chart Downloads</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      --accent: #03a9f4;
+      --border: #d8dee4;
+      --muted: #59636e;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    body {{
+      margin: 0;
+      background: Canvas;
+      color: CanvasText;
+    }}
+    main {{
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 32px 20px 48px;
+    }}
+    h1 {{
+      margin: 0 0 8px;
+      font-size: 2rem;
+      font-weight: 650;
+    }}
+    p {{
+      color: var(--muted);
+      line-height: 1.5;
+    }}
+    .summary {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      margin: 24px 0;
+    }}
+    .metric {{
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 16px;
+    }}
+    .metric strong {{
+      display: block;
+      font-size: 1.65rem;
+      margin-bottom: 4px;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 16px;
+      font-size: 0.95rem;
+    }}
+    th, td {{
+      border-bottom: 1px solid var(--border);
+      padding: 10px 8px;
+      text-align: left;
+    }}
+    th {{
+      font-weight: 650;
+    }}
+    td:last-child, th:last-child {{
+      text-align: right;
+    }}
+    code {{
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Home Assistant Helm Chart Downloads</h1>
+    <p>
+      These are GitHub release asset downloads, not confirmed installs. A single
+      user can download multiple chart versions, and CI jobs, retries, mirrors,
+      or cache misses may also increment the count.
+    </p>
+
+    <section class="summary" aria-label="Download summary">
+      <div class="metric">
+        <strong>{total_downloads}</strong>
+        <span>chart downloads</span>
+      </div>
+      <div class="metric">
+        <strong>{latest_version}</strong>
+        <span>latest chart version</span>
+      </div>
+      <div class="metric">
+        <strong>{latest_downloads}</strong>
+        <span>latest version downloads</span>
+      </div>
+      <div class="metric">
+        <strong>{release_count}</strong>
+        <span>chart releases counted</span>
+      </div>
+    </section>
+
+    <p>Last updated: <code>{generated_at}</code></p>
+
+    <h2>Downloads by Version</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Version</th>
+          <th>Release tag</th>
+          <th>Downloads</th>
+        </tr>
+      </thead>
+      <tbody>
+{rows}
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>
+"""
+
+
+def build_version_row(version):
+    return (
+        "        <tr>"
+        f"<td>{html.escape(version['version'])}</td>"
+        f"<td>{html.escape(version['tagName'])}</td>"
+        f"<td>{version['downloadCount']:,}</td>"
+        "</tr>"
+    )
+
+
+def load_releases_from_file(path):
+    with Path(path).open(encoding="utf-8") as release_file:
+        return json.load(release_file)
+
+
+def fetch_releases(repo, token=None):
+    releases = []
+    url = f"https://api.github.com/repos/{repo}/releases?per_page=100"
+
+    while url:
+        request = urllib.request.Request(url, headers=api_headers(token))
+        with urllib.request.urlopen(request, timeout=30) as response:
+            releases.extend(json.load(response))
+            url = next_link(response.headers.get("Link"))
+
+    return releases
+
+
+def api_headers(token=None):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": API_VERSION,
+        "User-Agent": "home-assistant-helm-chart-download-stats",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def next_link(link_header):
+    if not link_header:
+        return None
+
+    for part in link_header.split(","):
+        pieces = [piece.strip() for piece in part.split(";")]
+        if len(pieces) < 2:
+            continue
+        link = pieces[0]
+        rel = next((piece for piece in pieces[1:] if piece == 'rel="next"'), None)
+        if rel and link.startswith("<") and link.endswith(">"):
+            return link[1:-1]
+    return None
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Generate Helm chart download stats")
+    source = parser.add_mutually_exclusive_group(required=False)
+    source.add_argument("--input", help="Path to a GitHub releases JSON fixture")
+    source.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/repo")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--generated-at", help="Override generated timestamp")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    if args.input:
+        releases = load_releases_from_file(args.input)
+    else:
+        if not args.repo:
+            raise SystemExit("--repo is required when GITHUB_REPOSITORY is not set")
+        releases = fetch_releases(args.repo, token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"))
+
+    stats = build_stats(releases, generated_at=args.generated_at)
+    write_outputs(stats, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/chart_download_stats_test.py
+++ b/.github/scripts/chart_download_stats_test.py
@@ -1,0 +1,88 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODULE_PATH = SCRIPT_DIR / "chart_download_stats.py"
+FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "releases.json"
+
+
+class ChartDownloadStatsTest(unittest.TestCase):
+    def load_module(self):
+        self.assertTrue(
+            MODULE_PATH.exists(),
+            "chart_download_stats.py should exist before generator tests can run",
+        )
+        spec = importlib.util.spec_from_file_location("chart_download_stats", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def load_releases(self):
+        with FIXTURE_PATH.open() as fixture:
+            return json.load(fixture)
+
+    def test_build_stats_aggregates_chart_archive_downloads(self):
+        module = self.load_module()
+
+        stats = module.build_stats(
+            self.load_releases(),
+            generated_at="2026-06-12T00:00:00Z",
+        )
+
+        self.assertEqual(55445, stats["totalDownloads"])
+        self.assertEqual(4, stats["releaseCount"])
+        self.assertEqual("0.3.65", stats["latestVersion"])
+        self.assertEqual(1, stats["latestVersionDownloads"])
+        self.assertEqual(
+            ["0.3.65", "0.3.64", "0.3.63", "0.2.102"],
+            [version["version"] for version in stats["versions"]],
+        )
+        self.assertEqual(
+            {"version": "0.2.102", "downloadCount": 53037},
+            stats["topVersions"][0],
+        )
+
+    def test_compact_count_uses_floor_for_badge_values(self):
+        module = self.load_module()
+
+        self.assertEqual("999", module.compact_count(999))
+        self.assertEqual("1k", module.compact_count(1000))
+        self.assertEqual("471k", module.compact_count(471856))
+        self.assertEqual("1.2M", module.compact_count(1234567))
+
+    def test_write_outputs_badge_json_and_escaped_dashboard(self):
+        module = self.load_module()
+        stats = module.build_stats(
+            self.load_releases(),
+            generated_at="2026-06-12T00:00:00Z",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            module.write_outputs(stats, output_dir)
+
+            downloads = json.loads((output_dir / "stats" / "downloads.json").read_text())
+            badge = json.loads((output_dir / "stats" / "downloads-badge.json").read_text())
+            dashboard = (output_dir / "stats" / "index.html").read_text()
+
+        self.assertEqual(stats, downloads)
+        self.assertEqual(
+            {
+                "schemaVersion": 1,
+                "label": "chart downloads",
+                "message": "55k",
+                "color": "blue",
+            },
+            badge,
+        )
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", dashboard)
+        self.assertNotIn("<script>alert(1)</script>", dashboard)
+        self.assertIn("GitHub release asset downloads, not confirmed installs", dashboard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/fixtures/releases.json
+++ b/.github/scripts/fixtures/releases.json
@@ -1,0 +1,51 @@
+[
+  {
+    "tag_name": "home-assistant-0.3.64",
+    "assets": [
+      {
+        "name": "home-assistant-0.3.64.tgz",
+        "download_count": 745
+      },
+      {
+        "name": "home-assistant-0.3.64.prov",
+        "download_count": 999
+      }
+    ]
+  },
+  {
+    "tag_name": "home-assistant-0.3.63",
+    "assets": [
+      {
+        "name": "home-assistant-0.3.63.tgz",
+        "download_count": 1662
+      }
+    ]
+  },
+  {
+    "tag_name": "home-assistant-0.2.102",
+    "assets": [
+      {
+        "name": "home-assistant-0.2.102.tgz",
+        "download_count": 53037
+      }
+    ]
+  },
+  {
+    "tag_name": "<script>alert(1)</script>",
+    "assets": [
+      {
+        "name": "home-assistant-0.3.65.tgz",
+        "download_count": 1
+      }
+    ]
+  },
+  {
+    "tag_name": "not-a-chart",
+    "assets": [
+      {
+        "name": "not-home-assistant-1.0.0.tgz",
+        "download_count": 99
+      }
+    ]
+  }
+]

--- a/.github/workflows/build-helm-chart-release.yaml
+++ b/.github/workflows/build-helm-chart-release.yaml
@@ -14,6 +14,10 @@ on:
         required: true
         default: 'patch'
 
+concurrency:
+  group: gh-pages-publish
+  cancel-in-progress: false
+
 jobs:
   release:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
@@ -69,5 +73,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
-
 

--- a/.github/workflows/chart-download-stats.yaml
+++ b/.github/workflows/chart-download-stats.yaml
@@ -1,0 +1,71 @@
+name: Chart Download Stats
+
+on:
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gh-pages-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Generate download stats
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python .github/scripts/chart_download_stats.py --repo "$GITHUB_REPOSITORY" --output generated-stats
+
+      - name: Checkout GitHub Pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
+
+      - name: Publish stats to GitHub Pages
+        working-directory: gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          mkdir -p stats
+          cp ../generated-stats/stats/downloads.json stats/downloads.json
+          cp ../generated-stats/stats/downloads-badge.json stats/downloads-badge.json
+          cp ../generated-stats/stats/index.html stats/index.html
+          touch .nojekyll
+
+          git add .nojekyll stats/downloads.json stats/downloads-badge.json stats/index.html
+          if git diff --cached --quiet; then
+            echo "No stats changes to publish."
+            exit 0
+          fi
+
+          git commit -m "Update chart download stats"
+
+          for attempt in 1 2; do
+            git pull --rebase origin gh-pages
+            if git push origin HEAD:gh-pages; then
+              exit 0
+            fi
+
+            if [ "$attempt" = "2" ]; then
+              exit 1
+            fi
+
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+          done

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Latest Released Version](https://img.shields.io/github/v/tag/pajikos/home-assistant-helm-chart?sort=semver)
 ![Helm Chart Release](https://github.com/pajikos/home-assistant-helm-chart/actions/workflows/build-helm-chart-release.yaml/badge.svg)
 ![Auto-update latest HA version](https://github.com/pajikos/home-assistant-helm-chart/actions/workflows/check_ha_release.yml/badge.svg)
+![Chart Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fpajikos.github.io%2Fhome-assistant-helm-chart%2Fstats%2Fdownloads-badge.json)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/helm-hass)](https://artifacthub.io/packages/search?repo=helm-hass)
 
 ## Introduction

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -3,6 +3,7 @@
 ![Latest Released Version](https://img.shields.io/github/v/tag/pajikos/home-assistant-helm-chart?sort=semver)
 ![Helm Chart Release](https://github.com/pajikos/home-assistant-helm-chart/actions/workflows/build-helm-chart-release.yaml/badge.svg)
 ![Auto-update latest HA version](https://github.com/pajikos/home-assistant-helm-chart/actions/workflows/check_ha_release.yml/badge.svg)
+![Chart Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fpajikos.github.io%2Fhome-assistant-helm-chart%2Fstats%2Fdownloads-badge.json)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/helm-hass)](https://artifacthub.io/packages/search?repo=helm-hass)
 
 ## Introduction


### PR DESCRIPTION
## Summary
- Add a Python generator for GitHub release asset download stats, including Shields badge JSON and a static dashboard.
- Add a scheduled/manual workflow that publishes generated stats to gh-pages with shared publish concurrency.
- Add the chart downloads badge to the chart README and root README.

## Test Plan
- PYTHONDONTWRITEBYTECODE=1 python .github/scripts/chart_download_stats_test.py
- PYTHONDONTWRITEBYTECODE=1 python .github/scripts/chart_download_stats.py --input .github/scripts/fixtures/releases.json --output /tmp/chart-download-stats-pr-postcommit --generated-at 2026-06-12T00:00:00Z
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/chart-download-stats.yaml .github/workflows/build-helm-chart-release.yaml
- git diff --check HEAD~1..HEAD