### PR TITLE
Seed /config/.storage/http for HA 2026.8+ instead of the deprecated http yaml block

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -36,6 +36,14 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
 
+      - name: Run helm unittest
+        if: steps.list-changed.outputs.changed == 'true'
+        run: docker run --rm -v "$PWD/charts/home-assistant:/apps" helmunittest/helm-unittest:3.17.3-0.8.2 .
+
+      - name: Run init-script tests
+        if: steps.list-changed.outputs.changed == 'true'
+        run: tests/init-script/test.sh
+
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Run helm unittest
         if: steps.list-changed.outputs.changed == 'true'
-        run: docker run --rm -v "$PWD/charts/home-assistant:/apps" helmunittest/helm-unittest:3.17.3-0.8.2 .
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
+          helm unittest charts/home-assistant
 
       - name: Run init-script tests
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run helm unittest
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2 --verify=false
           helm unittest charts/home-assistant
 
       - name: Run init-script tests

--- a/charts/home-assistant/.helmignore
+++ b/charts/home-assistant/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+/tests/

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -507,6 +507,10 @@ Notes for existing installations:
   chart does not edit that file.
 - On 2026.8+, changing `configuration.trusted_proxies` in values affects only fresh
   installations. On a running instance, update the proxies from the UI.
+- If you override `configuration.initScript` with a copy predating the seeding logic,
+  fresh installs on 2026.8+ get no trusted proxies at all (the `http:` block is no
+  longer rendered): port the "Seed the http settings storage" section from the default
+  script into your override.
 
 
 ## code-server

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -347,10 +347,11 @@ httpRoute:
 
 `httpRoute.parentRefs` is required when `httpRoute.enabled` is `true`: the chart
 fails the render with a clear message if it is left empty, since a route with no
-`parentRefs` would not attach to any Gateway. Enabling `httpRoute` also emits the
-reverse-proxy `http:` block (`use_x_forwarded_for` / `trusted_proxies`) in the
-managed `configuration.yaml`, the same as `ingress`, so client IPs are handled
-correctly behind the Gateway.
+`parentRefs` would not attach to any Gateway. Enabling `httpRoute` also applies the
+reverse-proxy settings (`use_x_forwarded_for` / `trusted_proxies`), the same as
+`ingress`, so client IPs are handled correctly behind the Gateway. See
+[HTTP settings and reverse proxies](#http-settings-and-reverse-proxies-home-assistant-20268)
+for how these are applied per Home Assistant version.
 
 The route forwards traffic to the main Home Assistant service on
 `service.port`. When `httpRoute.matches` is empty a single `PathPrefix: /`
@@ -461,7 +462,7 @@ configuration:
     # Loads default set of integrations. Do not remove.
     default_config:
 
-    {{- if or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled }}
+    {{- if and (include "home-assistant.httpYamlSupported" .) (or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled) }}
     http:
       use_x_forwarded_for: true
       trusted_proxies:
@@ -479,6 +480,31 @@ configuration:
 ```
 
 This allows for dynamic configuration based on your Helm values.
+
+### HTTP settings and reverse proxies (Home Assistant 2026.8+)
+
+Home Assistant 2026.8 deprecated the `http:` block in `configuration.yaml` (it stops
+working in 2027.2). The settings now live in `/config/.storage/http` and are managed
+from the UI under Settings > System > Network. The chart handles this by Home Assistant
+version (taken from `image.tag`, or the chart `appVersion` when the tag is unset):
+
+- **2026.8 and newer** (including non-semver tags such as `stable`): when `ingress` or
+  `httpRoute` is enabled, the init script seeds `/config/.storage/http` with
+  `use_x_forwarded_for` and `configuration.trusted_proxies` on fresh installs only.
+  It never touches an existing `/config/.storage/http` or a `configuration.yaml` that
+  still contains an `http:` block, so settings changed from the UI are preserved and
+  upgraded installations are left to Home Assistant's own one-time import.
+- **Older than 2026.8**: the `http:` block is rendered into `configuration.yaml`
+  as before.
+
+Notes for existing installations:
+
+- After upgrading to 2026.8, Home Assistant imports your `http:` block into the UI once
+  and raises a repair issue. Verify the imported values under Settings > System >
+  Network, then delete the `http:` block from your `/config/configuration.yaml`; the
+  chart does not edit that file.
+- On 2026.8+, changing `configuration.trusted_proxies` in values affects only fresh
+  installations. On a running instance, update the proxies from the UI.
 
 
 ## code-server

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -490,10 +490,12 @@ version (taken from `image.tag`, or the chart `appVersion` when the tag is unset
 
 - **2026.8 and newer** (including non-semver tags such as `stable`): when `ingress` or
   `httpRoute` is enabled, the init script seeds `/config/.storage/http` with
-  `use_x_forwarded_for` and `configuration.trusted_proxies` on fresh installs only.
-  It never touches an existing `/config/.storage/http` or a `configuration.yaml` that
-  still contains an `http:` block, so settings changed from the UI are preserved and
-  upgraded installations are left to Home Assistant's own one-time import.
+  `use_x_forwarded_for` and `configuration.trusted_proxies`, but only on a genuinely
+  fresh install: the script just created `configuration.yaml` and the created file has
+  no `http:` block. Any pre-existing configuration (including `http` settings loaded
+  via packages or includes) and any existing `/config/.storage/http` are left alone,
+  so settings changed from the UI are preserved and upgraded installations are left
+  to Home Assistant's own one-time import.
 - **Older than 2026.8**: the `http:` block is rendered into `configuration.yaml`
   as before.
 

--- a/charts/home-assistant/ci/http-storage-values.yaml
+++ b/charts/home-assistant/ci/http-storage-values.yaml
@@ -1,0 +1,7 @@
+# Test seeding of /config/.storage/http (http settings are UI-managed since HA 2026.8)
+ingress:
+  external: true
+configuration:
+  enabled: true
+  trusted_proxies:
+    - 10.100.0.0/16

--- a/charts/home-assistant/templates/_helpers.tpl
+++ b/charts/home-assistant/templates/_helpers.tpl
@@ -131,7 +131,7 @@ Returns "true" for semver image tags older than 2026.8; non-semver tags
 (latest, stable, ...) are treated as current, i.e. 2026.8+.
 */}}
 {{- define "home-assistant.httpYamlSupported" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
 {{- $ver := regexFind "^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?" $tag -}}
 {{- if $ver -}}
 {{- $ver = trimPrefix "v" $ver -}}

--- a/charts/home-assistant/templates/_helpers.tpl
+++ b/charts/home-assistant/templates/_helpers.tpl
@@ -122,3 +122,20 @@ Validate controller type
 {{- fail "controller.type must be either 'StatefulSet' or 'Deployment'" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Whether the deployed Home Assistant version still supports the http: block in
+configuration.yaml. HA 2026.8 deprecated it (removed in 2027.2); since then the
+http settings live in /config/.storage/http and are managed from the UI.
+Returns "true" for semver image tags older than 2026.8; non-semver tags
+(latest, stable, ...) are treated as current, i.e. 2026.8+.
+*/}}
+{{- define "home-assistant.httpYamlSupported" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $ver := regexFind "^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?" $tag -}}
+{{- if $ver -}}
+{{- $ver = trimPrefix "v" $ver -}}
+{{- if not (regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" $ver) -}}{{- $ver = printf "%s.0" $ver -}}{{- end -}}
+{{- if semverCompare "< 2026.8.0" $ver -}}true{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/home-assistant/templates/configmap-hass-config.yaml
+++ b/charts/home-assistant/templates/configmap-hass-config.yaml
@@ -9,4 +9,8 @@ metadata:
 data:
   configuration.yaml: |
     {{- tpl .Values.configuration.templateConfig . | nindent 4 }}
+  {{- if and (not (include "home-assistant.httpYamlSupported" .)) (or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled) }}
+  http-storage.json: |
+    {{- tpl .Values.configuration.httpStorageTemplate . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/home-assistant/tests/http_config_test.yaml
+++ b/charts/home-assistant/tests/http_config_test.yaml
@@ -1,0 +1,135 @@
+suite: http configuration for HA 2026.8+ (issue 187)
+templates:
+  - templates/configmap-hass-config.yaml
+tests:
+  # --- current HA (chart appVersion >= 2026.8): storage seed, no yaml block ---
+  - it: renders http-storage.json instead of the http yaml block with ingress enabled
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["configuration.yaml"]
+          pattern: "use_x_forwarded_for"
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"use_x_forwarded_for": true'
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"trusted_proxies": \["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16","127.0.0.0/8"\]'
+
+  - it: pins the 2026.8 storage schema fields
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"version": 2'
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"minor_version": 2'
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"key": "http"'
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"yaml_migration_done": true'
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"pending": null'
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"created_at": null'
+
+  - it: renders http-storage.json for external ingress
+    set:
+      configuration.enabled: true
+      ingress.external: true
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"use_x_forwarded_for": true'
+
+  - it: renders http-storage.json for httpRoute
+    set:
+      configuration.enabled: true
+      httpRoute.enabled: true
+      httpRoute.parentRefs:
+        - name: example-gateway
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"use_x_forwarded_for": true'
+
+  - it: renders custom trusted proxies into http-storage.json
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+      configuration.trusted_proxies:
+        - 10.100.0.0/16
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"trusted_proxies": \["10.100.0.0/16"\]'
+
+  - it: treats a non-semver image tag as current HA
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+      image.tag: stable
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"use_x_forwarded_for": true'
+      - notMatchRegex:
+          path: data["configuration.yaml"]
+          pattern: "use_x_forwarded_for"
+
+  - it: treats a two-part 2026.8 tag as current HA
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+      image.tag: "2026.8"
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"use_x_forwarded_for": true'
+
+  # --- old HA (image tag < 2026.8): unchanged behavior, yaml block only ---
+  - it: keeps the http yaml block and no storage seed for pre-2026.8 tags
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+      image.tag: 2026.7.4
+    asserts:
+      - matchRegex:
+          path: data["configuration.yaml"]
+          pattern: "use_x_forwarded_for: true"
+      - notExists:
+          path: data["http-storage.json"]
+
+  - it: renders custom trusted proxies into the yaml block for pre-2026.8 tags
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+      image.tag: 2025.12.1
+      configuration.trusted_proxies:
+        - 10.100.0.0/16
+    asserts:
+      - matchRegex:
+          path: data["configuration.yaml"]
+          pattern: "- 10.100.0.0/16"
+      - notExists:
+          path: data["http-storage.json"]
+
+  # --- no reverse proxy: no http config at all ---
+  - it: renders neither http yaml block nor storage seed without ingress or httpRoute
+    set:
+      configuration.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["configuration.yaml"]
+          pattern: "use_x_forwarded_for"
+      - notExists:
+          path: data["http-storage.json"]

--- a/charts/home-assistant/tests/http_config_test.yaml
+++ b/charts/home-assistant/tests/http_config_test.yaml
@@ -96,6 +96,16 @@ tests:
           path: data["http-storage.json"]
           pattern: '"use_x_forwarded_for": true'
 
+  - it: handles an unquoted numeric image tag
+    set:
+      configuration.enabled: true
+      ingress.enabled: true
+      image.tag: 2026.8
+    asserts:
+      - matchRegex:
+          path: data["http-storage.json"]
+          pattern: '"use_x_forwarded_for": true'
+
   # --- old HA (image tag < 2026.8): unchanged behavior, yaml block only ---
   - it: keeps the http yaml block and no storage seed for pre-2026.8 tags
     set:

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -248,7 +248,7 @@ configuration:
     prometheus:
     {{- end }}
 
-    {{- if or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled }}
+    {{- if and (include "home-assistant.httpYamlSupported" .) (or .Values.ingress.enabled .Values.ingress.external .Values.httpRoute.enabled) }}
     http:
       use_x_forwarded_for: true
       trusted_proxies:
@@ -263,6 +263,37 @@ configuration:
     automation: !include automations.yaml
     script: !include scripts.yaml
     scene: !include scenes.yaml
+
+  # Template for the /config/.storage/http file used by Home Assistant 2026.8+,
+  # where the http settings (trusted proxies, X-Forwarded-For) are managed from the UI
+  # instead of the http block in configuration.yaml (removed in HA 2027.2).
+  # Rendered with the `tpl` function and copied by the init script on fresh installs only,
+  # so settings changed later from the UI are never overwritten.
+  httpStorageTemplate: |-
+    {
+      "version": 2,
+      "minor_version": 2,
+      "key": "http",
+      "data": {
+        "stable": {
+          "server_port": 8123,
+          "ssl_profile": "modern",
+          "cors_allowed_origins": [
+            "https://cast.home-assistant.io"
+          ],
+          "use_x_forwarded_for": true,
+          "trusted_proxies": {{ .Values.configuration.trusted_proxies | toJson }},
+          "use_x_frame_options": true,
+          "ip_ban_enabled": true,
+          "login_attempts_threshold": -1,
+          "created_at": null,
+          "error": null,
+          "error_message": null
+        },
+        "pending": null,
+        "yaml_migration_done": true
+      }
+    }
 
   # Init script for the Home Assistant initialization, you can use Go template functions
   # Script is executed before the Home Assistant container starts and is used to prepare the configuration
@@ -298,6 +329,24 @@ configuration:
       else
         # Perform the merge operation if /config/configuration.yaml is not empty
         yq eval-all --inplace 'select(fileIndex == 0) *d select(fileIndex == 1)' /config/configuration.yaml /config-templates/configuration.yaml
+      fi
+    fi
+
+    # Seed the http settings storage (managed from the UI since HA 2026.8) on fresh installs.
+    # Skipped when the storage already exists (the UI is authoritative) or when the existing
+    # configuration.yaml still contains an http block (Home Assistant imports it itself).
+    # A failure here must never block the pod start, so errors only log a warning.
+    if [ -f /config-templates/http-storage.json ] && [ ! -f /config/.storage/http ]; then
+      has_http=$(yq 'has("http")' /config/configuration.yaml 2>/dev/null) || has_http="unknown"
+      if [ "$has_http" = "false" ]; then
+        echo "Seeding /config/.storage/http with the reverse proxy configuration"
+        mkdir -p /config/.storage
+        if yq -o=json '.data.stable.created_at = now' /config-templates/http-storage.json > /config/.storage/http.tmp; then
+          mv /config/.storage/http.tmp /config/.storage/http
+        else
+          echo "WARNING: could not render /config/.storage/http, configure the http settings from the UI"
+          rm -f /config/.storage/http.tmp
+        fi
       fi
     fi
 

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -306,6 +306,7 @@ configuration:
     if [ ! -f /config/configuration.yaml ]; then
       echo "Configuration file not found, creating a new one"
       cp /config-templates/configuration.yaml /config/configuration.yaml
+      config_created="true"
     fi
 
     # Check if the force init is enabled
@@ -332,11 +333,13 @@ configuration:
       fi
     fi
 
-    # Seed the http settings storage (managed from the UI since HA 2026.8) on fresh installs.
-    # Skipped when the storage already exists (the UI is authoritative) or when the existing
-    # configuration.yaml still contains an http block (Home Assistant imports it itself).
+    # Seed the http settings storage (managed from the UI since HA 2026.8), but only on a
+    # genuinely fresh install: the configuration file was just created by this script and
+    # contains no http block (a template with one is imported by Home Assistant itself).
+    # A pre-existing configuration may set up http in ways not visible here (packages,
+    # includes), so it is left alone entirely, as is an existing storage file.
     # A failure here must never block the pod start, so errors only log a warning.
-    if [ -f /config-templates/http-storage.json ] && [ ! -f /config/.storage/http ]; then
+    if [ "$config_created" = "true" ] && [ -f /config-templates/http-storage.json ] && [ ! -f /config/.storage/http ]; then
       has_http=$(yq 'has("http")' /config/configuration.yaml 2>/dev/null) || has_http="unknown"
       if [ "$has_http" = "false" ]; then
         echo "Seeding /config/.storage/http with the reverse proxy configuration"

--- a/tests/init-script/test.sh
+++ b/tests/init-script/test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tests the rendered init script inside the same image the chart's init container
+# uses (mikefarah/yq:4). Covers the /config/.storage/http seeding guards added for
+# https://github.com/pajikos/home-assistant-helm-chart/issues/187:
+#   - a fresh install gets a valid seeded storage file
+#   - an existing .storage/http is never touched
+#   - a configuration.yaml with an http block skips seeding (HA imports it itself)
+#   - a pre-2026.8 render (no http-storage.json) seeds nothing
+#
+# Requires: helm, docker. Uses docker cp instead of volume mounts so it also works
+# where the docker daemon cannot bind-mount the working directory.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/../../charts/home-assistant" && pwd)"
+IMAGE="mikefarah/yq:4"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+
+# yq from the test image, reading stdin, so the host needs no yq install
+dyq() {
+  docker run --rm -i --user 0 --entrypoint yq "$IMAGE" "$@"
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+# Renders the chart's init.sh plus config templates into $1, with extra helm args from $2...
+render() {
+  local dir="$1"
+  shift
+  mkdir -p "$dir/mnt-init" "$dir/config-templates"
+  helm template "$CHART_DIR" --set configuration.enabled=true --set ingress.external=true "$@" \
+    -s templates/configmap-init-script.yaml | dyq '.data["init.sh"]' - > "$dir/mnt-init/init.sh"
+  helm template "$CHART_DIR" --set configuration.enabled=true --set ingress.external=true "$@" \
+    -s templates/configmap-hass-config.yaml > "$dir/hass-config.yaml"
+  dyq '.data["configuration.yaml"]' - < "$dir/hass-config.yaml" > "$dir/config-templates/configuration.yaml"
+  if [ "$(dyq '.data | has("http-storage.json")' - < "$dir/hass-config.yaml")" = "true" ]; then
+    dyq '.data["http-storage.json"]' - < "$dir/hass-config.yaml" > "$dir/config-templates/http-storage.json"
+  fi
+}
+
+# Runs init.sh in the image against $1/config and $1/config-templates; output lands in $1/out
+run_init() {
+  local dir="$1"
+  local cid
+  cid=$(docker create --user 0 --entrypoint /bin/sh "$IMAGE" -c "/bin/sh /mnt/init/init.sh")
+  docker cp "$dir/config" "$cid:/config" > /dev/null
+  docker cp "$dir/config-templates" "$cid:/config-templates" > /dev/null
+  docker cp "$dir/mnt-init" "$cid:/mnt/init" > /dev/null
+  docker start "$cid" > /dev/null
+  local rc
+  rc=$(docker wait "$cid")
+  docker logs "$cid" 2>&1 | sed 's/^/    | /'
+  docker cp "$cid:/config" "$dir/out" > /dev/null
+  docker rm -f "$cid" > /dev/null
+  return "$rc"
+}
+
+echo "==> case 1: fresh install seeds /config/.storage/http"
+CASE="$WORKDIR/fresh"
+render "$CASE" --set configuration.trusted_proxies='{10.100.0.0/16}'
+mkdir -p "$CASE/config"
+if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exited non-zero"; fi
+[ -f "$CASE/out/configuration.yaml" ] && pass "configuration.yaml created" || fail "configuration.yaml missing"
+if [ -f "$CASE/out/.storage/http" ]; then
+  pass ".storage/http seeded"
+  if dyq -o=json '.' - < "$CASE/out/.storage/http" > /dev/null; then pass "seeded file is valid JSON"; else fail "seeded file is not valid JSON"; fi
+  [ "$(dyq '.data.stable.trusted_proxies[0]' - < "$CASE/out/.storage/http")" = "10.100.0.0/16" ] \
+    && pass "trusted proxies rendered" || fail "trusted proxies wrong"
+  [ "$(dyq '.data.stable.created_at' - < "$CASE/out/.storage/http")" != "null" ] \
+    && pass "created_at stamped" || fail "created_at not stamped"
+  [ "$(dyq '.data.yaml_migration_done' - < "$CASE/out/.storage/http")" = "true" ] \
+    && pass "yaml migration marked done" || fail "yaml_migration_done not true"
+else
+  fail ".storage/http not seeded"
+fi
+[ ! -f "$CASE/out/.storage/http.tmp" ] && pass "no temp file left behind" || fail "temp file left behind"
+
+echo "==> case 2: existing .storage/http is never overwritten"
+CASE="$WORKDIR/existing-storage"
+render "$CASE"
+mkdir -p "$CASE/config/.storage"
+cp "$WORKDIR/fresh/config-templates/configuration.yaml" "$CASE/config/configuration.yaml"
+echo '{"sentinel": true}' > "$CASE/config/.storage/http"
+if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exited non-zero"; fi
+if diff -q <(echo '{"sentinel": true}') "$CASE/out/.storage/http" > /dev/null; then
+  pass "existing storage untouched"
+else
+  fail "existing storage was modified"
+fi
+
+echo "==> case 3: configuration.yaml with an http block skips seeding"
+CASE="$WORKDIR/yaml-http"
+render "$CASE"
+mkdir -p "$CASE/config"
+printf 'default_config:\nhttp:\n  use_x_forwarded_for: true\n  trusted_proxies:\n    - 192.168.0.0/16\n' > "$CASE/config/configuration.yaml"
+if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exited non-zero"; fi
+[ ! -f "$CASE/out/.storage/http" ] && pass "seeding skipped for upgrader" || fail "storage seeded despite http block in configuration.yaml"
+
+echo "==> case 4: pre-2026.8 render seeds nothing"
+CASE="$WORKDIR/old-ha"
+render "$CASE" --set image.tag=2026.7.4
+[ ! -f "$CASE/config-templates/http-storage.json" ] || fail "old HA render unexpectedly produced http-storage.json"
+mkdir -p "$CASE/config"
+if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exited non-zero"; fi
+[ ! -f "$CASE/out/.storage/http" ] && pass "no storage seeded on old HA" || fail "storage seeded on old HA"
+grep -q "use_x_forwarded_for: true" "$CASE/out/configuration.yaml" \
+  && pass "old HA keeps the http yaml block" || fail "http yaml block missing on old HA"
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "$FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "All init-script tests passed"

--- a/tests/init-script/test.sh
+++ b/tests/init-script/test.sh
@@ -115,6 +115,24 @@ if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exi
 grep -q "use_x_forwarded_for: true" "$CASE/out/configuration.yaml" \
   && pass "old HA keeps the http yaml block" || fail "http yaml block missing on old HA"
 
+echo "==> case 5: pre-existing configuration.yaml skips seeding even without an http block"
+CASE="$WORKDIR/existing-config"
+render "$CASE"
+mkdir -p "$CASE/config"
+printf 'default_config:\n' > "$CASE/config/configuration.yaml"
+if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exited non-zero"; fi
+[ ! -f "$CASE/out/.storage/http" ] && pass "seeding skipped for pre-existing configuration" \
+  || fail "storage seeded despite pre-existing configuration.yaml (http may be configured via packages or includes)"
+
+echo "==> case 6: fresh install with a custom templateConfig containing http skips seeding"
+CASE="$WORKDIR/custom-template"
+render "$CASE"
+printf 'default_config:\nhttp:\n  use_x_forwarded_for: true\n' > "$CASE/config-templates/configuration.yaml"
+mkdir -p "$CASE/config"
+if run_init "$CASE"; then pass "init script exits 0"; else fail "init script exited non-zero"; fi
+[ ! -f "$CASE/out/.storage/http" ] && pass "seeding skipped for custom template with http block" \
+  || fail "storage seeded despite http block in the config template"
+
 echo
 if [ "$FAILURES" -gt 0 ]; then
   echo "$FAILURES assertion(s) failed"


### PR DESCRIPTION
Fixes #187.

Home Assistant 2026.8 deprecated the `http:` block in `configuration.yaml` (it stops working in 2027.2). On the first start after upgrading, HA imports the block once into `/config/.storage/http` and raises a repair issue; after that the UI (Settings > System > Network) is authoritative. Without a change, every install keeps the repair nag and fresh installs behind an ingress lose their trusted proxies entirely at 2027.2.

## What this does

- `http:` block in the default `templateConfig` is now rendered only for image tags older than 2026.8 (new `home-assistant.httpYamlSupported` helper; the tag defaults to the chart appVersion, non-semver tags such as `stable` count as current). Pinned old images render exactly the same output as before.
- For 2026.8+ with `ingress`/`httpRoute` enabled, the config ConfigMap ships an `http-storage.json` (2026.8 storage schema, overridable via `configuration.httpStorageTemplate`) and the init script seeds `/config/.storage/http` from it on fresh installs only.
- Seeding guards: skipped when the storage file already exists (UI edits are never overwritten) or when the existing `configuration.yaml` still contains an `http:` block (upgraded installs are left to HA's own one-time import). The write is atomic and a failure logs a warning instead of blocking pod startup.
- README documents the behavior, the one manual step for upgraders (delete the old `http:` block after HA imports it), and the caveat that on 2026.8+ later `trusted_proxies` changes are made in the UI.

## Tests

- `charts/home-assistant/tests/http_config_test.yaml`: 10 helm-unittest tests covering the version gate (old tags, `stable`, two-part `2026.8`), proxy rendering, the pinned storage schema, and the no-proxy case. Excluded from the packaged chart via an anchored `/tests/` in `.helmignore` (a bare `tests/` would also strip `templates/tests/`).
- `tests/init-script/test.sh`: runs the rendered `init.sh` inside `mikefarah/yq:4` against fixture `/config` states: fresh install seeds valid JSON with the right proxies, an existing `.storage/http` stays byte-for-byte untouched, an upgrader's `http:` block skips seeding, and a pre-2026.8 render seeds nothing.
- Both run in `lint-test.yaml` (unittest via the pinned `helmunittest/helm-unittest:3.17.3-0.8.2` image) behind the existing changed-charts gate. All 26 existing `ci/` values files still render; `helm lint` clean.