### PR TITLE
Publish chart to GHCR as an OCI artifact alongside the GitHub Pages repo

### DIFF
--- a/.github/workflows/build-helm-chart-release.yaml
+++ b/.github/workflows/build-helm-chart-release.yaml
@@ -24,6 +24,7 @@ jobs:
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,4 +74,10 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to GHCR (OCI)
+        run: helm push ".cr-release-packages/home-assistant-${VERSION}.tgz" oci://ghcr.io/${{ github.repository_owner }}/charts
 

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -28,6 +28,14 @@ $ helm repo update
 $ helm install home-assistant pajikos/home-assistant
 ```
 
+The chart is also published as an OCI artifact to GitHub Container Registry, so it can be installed without adding a repository:
+
+```console
+$ helm install home-assistant oci://ghcr.io/pajikos/charts/home-assistant
+```
+
+Add `--version <chart version>` to either command to pin a specific release.
+
 This will deploy Home Assistant with the default configuration. See the [Configuration](#configuration) section for details on customizing the deployment.
 
 


### PR DESCRIPTION
Closes #171

## Summary

Every release is now also pushed to GHCR as an OCI artifact, in parallel with the existing GitHub Pages helm repo. Both install paths work:

```console
helm repo add pajikos http://pajikos.github.io/home-assistant-helm-chart/
helm install home-assistant pajikos/home-assistant
```

```console
helm install home-assistant oci://ghcr.io/pajikos/charts/home-assistant
```

## Changes

- `build-helm-chart-release.yaml`: add `packages: write` permission; after `chart-releaser` runs, log in to GHCR with `GITHUB_TOKEN` and `helm push` the packaged chart from `.cr-release-packages/` to `oci://ghcr.io/pajikos/charts`. The gh-pages release flow is unchanged.
- `charts/home-assistant/README.md`: document the OCI install command under Quick Start.

Only new releases are published to GHCR; older versions remain available through the helm repo.

## Verification

- Workflow YAML parses; helm flags checked against Helm 3.15.
- `helm package` output filename matches the path used by the push step.
- `chart-releaser-action@v1.7.0` (`cr.sh`) packages into `.cr-release-packages` in the workspace, so the file exists when the push step runs.

The push step can only be exercised end-to-end by running a release.

## After merging

The first release creates `ghcr.io/pajikos/charts/home-assistant` as a private package. It has to be switched to public in the package settings before anonymous `helm install oci://...` works.