### PR TITLE
Read the chart version with yq -r so VERSION has no literal quotes

### DIFF
--- a/.github/workflows/build-helm-chart-release.yaml
+++ b/.github/workflows/build-helm-chart-release.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Get latest release version
         id: get_latest_release
         run: |
-          VERSION=$(yq '.version' charts/home-assistant/Chart.yaml)
+          VERSION=$(yq -r '.version' charts/home-assistant/Chart.yaml)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Version: $VERSION"
           


### PR DESCRIPTION
## Problem

The 0.3.77 release ([run 33377109077](https://github.com/pajikos/home-assistant-helm-chart/actions/runs/33377109077)) published to GitHub Pages as usual, but the new GHCR push step from #189 failed:

```
Error: .cr-release-packages/home-assistant-"0.3.77".tgz: no such file
```

The workflow pip-installs the Python `yq` (a jq wrapper), which prints strings JSON-quoted unless `-r` is given. `VERSION` has therefore contained literal double quotes in every release run. The commit step never noticed: its `-m "Released version ${{ env.VERSION }} ..."` argument absorbed the quotes as shell syntax (the 0.3.76 run log shows `git commit -m "Released version "0.3.76" of the helm chart"`). The push step expands `"${VERSION}"` inside its own quotes, where they survive as data.

## Fix

Use `yq -r '.version'` in the "Get latest release version" step. Mike Farah's `yq`, preinstalled on the runner image, accepts `-r` as well, so this holds whichever `yq` is first on PATH.

## Verification

Ran the step's script locally with Python `yq` 4.1.2 on PATH: it now writes `VERSION=0.3.77` to `GITHUB_ENV` and `home-assistant-${VERSION}.tgz` resolves to the packaged file. The old invocation reproduces the exact CI error.

0.3.77 is not on GHCR; the next release after this merges will be the first one pushed there.